### PR TITLE
Ft/foundation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Active package ownership
+/apps/api/ @InChordSync/backend
+/apps/web/ @InChordSync/web
+/apps/mobile/ @InChordSync/mobile
+/apps/contracts/ @InChordSync/blockchain
+/packages/api-client/ @InChordSync/platform
+/packages/blockchain/ @InChordSync/blockchain
+/packages/config/ @InChordSync/platform
+/packages/types/ @InChordSync/platform
+/docs/ @InChordSync/maintainers
+/.github/ @InChordSync/maintainers
+/history/ @InChordSync/maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,12 @@
 # Active package ownership
-/apps/api/ @InChordSync/backend
-/apps/web/ @InChordSync/web
-/apps/mobile/ @InChordSync/mobile
-/apps/contracts/ @InChordSync/blockchain
-/packages/api-client/ @InChordSync/platform
-/packages/blockchain/ @InChordSync/blockchain
-/packages/config/ @InChordSync/platform
-/packages/types/ @InChordSync/platform
-/docs/ @InChordSync/maintainers
-/.github/ @InChordSync/maintainers
-/history/ @InChordSync/maintainers
+/apps/api/ @ehigodwin
+/apps/web/ @ehigodwin
+/apps/mobile/ @ehigodwin
+/apps/contracts/ @ehigodwin
+/packages/api-client/ @ehigodwin
+/packages/blockchain/ @ehigodwin
+/packages/config/ @ehigodwin
+/packages/types/ @ehigodwin
+/docs/ @ehigodwin
+/.github/ @ehigodwin
+/history/ @ehigodwin

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,9 @@ next-env.d.ts
 
 # turbo
 .turbo
+
+# local roadmap and gh import helpers
+/docs/github-issue-roadmap.md
+/docs/github-issue-publisher.md
+/scripts/import-sprint-issues-to-gh.mjs
+/tooling/publish-github-issues.mjs

--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@
 - [API reference](./docs/phase-1-api-reference.md)
 - [Demo runbook](./docs/phase-1-demo-runbook.md)
 - [Completion checklist](./docs/phase-1-checklist.md)
+
+## Repository operating docs
+
+- [Repository inventory](./docs/repository-inventory.md)
+- [Archive boundary](./docs/archive-boundary.md)
+- [Ownership map](./docs/ownership-map.md)
+- [Workspace scripts](./docs/workspace-scripts.md)

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,11 @@
   "scripts": {
     "dev": "tsx watch src/server.ts",
     "build": "tsc -p tsconfig.json",
-    "start": "node dist/server.js"
+    "start": "node dist/server.js",
+    "lint": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "tsx --test tests/*.test.ts",
+    "check:env": "tsx src/config/validate-env.ts"
   },
   "dependencies": {
     "express": "^4.21.2"

--- a/apps/contracts/package.json
+++ b/apps/contracts/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "sh -c 'if command -v cargo >/dev/null 2>&1; then cargo build; else echo \"Skipping contracts build: cargo not installed\"; fi'",
     "lint": "echo 'No lint configured for @chordially/contracts'",
+    "typecheck": "echo 'No typecheck configured for @chordially/contracts'",
     "test": "echo 'No tests configured for @chordially/contracts'"
   }
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -7,6 +7,7 @@
     "dev": "expo start",
     "build": "sh -c 'expo export || echo \"Skipping mobile export: Expo build prerequisites are not fully configured yet\"'",
     "lint": "echo 'No lint configured for @chordially/mobile'",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "echo 'No tests configured for @chordially/mobile'"
   },
   "dependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,10 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "lint": "echo 'Package lint is currently handled from the workspace root for @chordially/web'",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "echo 'No tests configured for @chordially/web'"
   },
   "dependencies": {
     "next": "14.2.30",

--- a/docs/archive-boundary.md
+++ b/docs/archive-boundary.md
@@ -1,0 +1,22 @@
+# Archive Boundary
+
+The `history/` directory is preserved as a read-only archive of past implementation attempts, spikes, and discarded experiments. It exists to provide reference context, not a reusable code surface.
+
+## Archive Rules
+
+- Do not import code from `history/` directly into runtime packages.
+- If a historical artifact is worth reviving, re-implement it inside the active package structure and add tests rather than moving the file wholesale.
+- Keep all new experimental work out of `history/`. Use short-lived feature branches or package-local spike directories that can be reviewed and consolidated quickly.
+- Treat filenames in `history/` as historical breadcrumbs. They are not stable APIs, modules, or ownership indicators.
+
+## Contributor Guidance
+
+- Build new backend work in `apps/api/src`.
+- Build new web work in `apps/web/app`, `apps/web/components`, and `apps/web/lib`.
+- Build new mobile work in `apps/mobile` under the canonical app structure.
+- Use shared contracts from `packages/*` rather than copying types from archived files.
+
+## Review Expectations
+
+- Pull requests that revive ideas from `history/` should reference the archived file in the PR description and explain what was rewritten versus copied.
+- Reviewers should reject changes that treat archived files as production-ready building blocks.

--- a/docs/ownership-map.md
+++ b/docs/ownership-map.md
@@ -1,0 +1,20 @@
+# Ownership Map
+
+This map defines the default review ownership for the active Chordially codebase. It is intentionally package-based so contributors know where to open changes and who should review them.
+
+| Surface | Default owners | Scope |
+| --- | --- | --- |
+| `apps/api` | backend maintainers | API contracts, auth, realtime, payments, persistence, and operational middleware |
+| `apps/web` | web maintainers | Public web, artist dashboard, admin dashboard, UI system, and server actions |
+| `apps/mobile` | mobile maintainers | Expo app flows, native integrations, mobile navigation, and device behavior |
+| `apps/contracts`, `packages/blockchain` | blockchain maintainers | Stellar integration, wallet helpers, contract experiments, and chain-facing safety rules |
+| `packages/api-client`, `packages/types`, `packages/config` | platform maintainers | Shared contracts, shared tooling, and cross-package configuration |
+| `docs`, `.github` | maintainers | Engineering docs, contribution guidance, CI, and release process |
+| `history` | maintainers | Archive-only oversight to prevent accidental product coupling |
+
+## Ownership Principles
+
+- Shared-package changes should request review from every downstream surface they affect.
+- Archive boundaries are owned by maintainers because accidental leakage from `history/` can destabilize the product.
+- Contributor spike directories do not imply long-term ownership. Canonical package roots do.
+- If a team surface grows materially, split ownership by subpath rather than relying on informal reviewer memory.

--- a/docs/repository-inventory.md
+++ b/docs/repository-inventory.md
@@ -1,0 +1,45 @@
+# Repository Inventory
+
+This document is the source of truth for which parts of the repository are active, which parts are experimental, and which parts should not be used as implementation targets for new feature work.
+
+## Active Product Surface
+
+These paths are the maintained foundation for Chordially:
+
+| Path | Status | Purpose |
+| --- | --- | --- |
+| `apps/api` | active | Express API and backend service composition |
+| `apps/web` | active | Next.js web application |
+| `apps/mobile` | active | Expo React Native application |
+| `apps/contracts` | active | Stellar contract workspace and contract experiments that are part of the current product direction |
+| `packages/api-client` | active | Shared API client helpers |
+| `packages/blockchain` | active | Shared blockchain utilities |
+| `packages/config` | active | Shared lint and TypeScript configuration |
+| `packages/types` | active | Shared domain contracts and API types |
+| `docs` | active | Product, architecture, deployment, and contributor documentation |
+| `.github` | active | CI and repository automation |
+
+## Legacy and Experimental Surface
+
+These paths are intentionally retained for reference only and must not be used as the base for new feature work:
+
+| Path | Status | Rationale |
+| --- | --- | --- |
+| `history` | archive-only | Prior implementation experiments, feature spikes, abandoned routes, and UI studies |
+| `apps/api/prisma` | prototype | Useful for reference during model design, but not yet the authoritative long-term MongoDB plan |
+| `apps/web/devwums`, `apps/web/wumibals` | experimental | Individual contributor spike directories that should be folded into stable app routes before reuse |
+| `apps/mobile/abdulmujib`, `apps/mobile/bellabuks`, `apps/mobile/leothosine` | experimental | Contributor-owned mobile spikes that need consolidation before shipping |
+| `apps/api/devwums`, `apps/api/wumibals`, `apps/api/abdulmujib` | experimental | Temporary backend spike directories pending consolidation into the module layout |
+
+## Decision Rules
+
+- New work should target the active package roots, not ad hoc contributor subdirectories.
+- Anything under `history/` is reference material only and should never be imported directly into production paths without review and refactoring.
+- If an experimental directory becomes canonical, migrate it into the stable package structure and remove the temporary subdirectory.
+- Duplicate lockfiles should be treated as temporary until package-management policy is finalized. The root workspace lockfile remains the primary source of truth.
+
+## Immediate Cleanup Targets
+
+- Consolidate package-level spike directories into stable module and route locations.
+- Replace malformed or prototype-only schema definitions with one authoritative data-model source.
+- Keep the ignored local issue-planning helpers untracked so operational execution artifacts do not leak into the repo.

--- a/docs/workspace-scripts.md
+++ b/docs/workspace-scripts.md
@@ -1,0 +1,26 @@
+# Workspace Scripts
+
+Chordially uses a small shared script vocabulary across packages so contributors can move between surfaces without relearning basic commands.
+
+## Standard Script Names
+
+| Script | Meaning |
+| --- | --- |
+| `dev` | Start the primary local development process for the package |
+| `build` | Build production artifacts or compile output where applicable |
+| `lint` | Run the package's static quality checks |
+| `typecheck` | Run TypeScript type validation for the package |
+| `test` | Run the package's automated test suite or a documented no-op placeholder |
+| `check:env` | Validate required environment variables for runnable applications |
+
+## Current Policy
+
+- Application packages should expose `dev`, `build`, `lint`, `typecheck`, and `test`.
+- Shared packages should expose `build` when they emit artifacts and should add at least `lint` and `typecheck` placeholders if deeper checks are not wired yet.
+- No-op placeholders are acceptable temporarily, but they must clearly state the missing capability.
+- Root scripts should orchestrate workspace-wide tasks without hiding which package command is being run.
+
+## Notes
+
+- `apps/api` now exposes `check:env` because its README already depends on it.
+- Package scripts should prefer local package checks over cross-package commands to keep failures scoped and understandable.

--- a/history/README.md
+++ b/history/README.md
@@ -1,0 +1,9 @@
+# History Archive
+
+This directory is an archive of earlier Chordially implementation attempts and spikes.
+
+- It is kept for reference only.
+- New feature work must not target files here.
+- If something in this archive is still useful, re-implement it in the active package structure instead of copying it into production paths unchanged.
+
+See [`docs/archive-boundary.md`](../docs/archive-boundary.md) for the repository policy.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "private": true,
   "packageManager": "pnpm@10.6.5",
   "scripts": {
+    "check": "pnpm lint && pnpm typecheck && pnpm test",
     "build": "turbo run build",
+    "dev:api": "pnpm --filter @chordially/api dev",
+    "dev:web": "pnpm --filter @chordially/web dev",
+    "dev:mobile": "pnpm --filter @chordially/mobile dev",
     "lint": "eslint .",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "turbo run test",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -2,6 +2,11 @@
   "name": "@chordially/api-client",
   "version": "0.1.0",
   "private": true,
+  "scripts": {
+    "lint": "echo 'No lint configured for @chordially/api-client'",
+    "typecheck": "echo 'No typecheck configured for @chordially/api-client'",
+    "test": "echo 'No tests configured for @chordially/api-client'"
+  },
   "main": "src/index.ts",
   "types": "src/index.ts"
 }

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -7,7 +7,9 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "lint": "echo 'No lint configured for @chordially/blockchain'"
+    "lint": "echo 'No lint configured for @chordially/blockchain'",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "echo 'No tests configured for @chordially/blockchain'"
   },
   "dependencies": {
     "stellar-sdk": "^12.2.0"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -2,6 +2,11 @@
   "name": "@chordially/config",
   "version": "0.1.0",
   "private": true,
+  "scripts": {
+    "lint": "echo 'No lint configured for @chordially/config'",
+    "typecheck": "echo 'No typecheck configured for @chordially/config'",
+    "test": "echo 'No tests configured for @chordially/config'"
+  },
   "main": "index.js",
   "files": [
     "tsconfig.base.json",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -2,6 +2,11 @@
   "name": "@chordially/types",
   "version": "0.1.0",
   "private": true,
+  "scripts": {
+    "lint": "echo 'No lint configured for @chordially/types'",
+    "typecheck": "echo 'No typecheck configured for @chordially/types'",
+    "test": "echo 'No tests configured for @chordially/types'"
+  },
   "main": "src/index.ts",
   "types": "src/index.ts"
 }


### PR DESCRIPTION
- document the authoritative repository inventory and cleanup targets
- define an explicit archive boundary for `history/`
- add a package-level ownership map and valid `CODEOWNERS`
- normalize workspace script names and restore the missing API `check:env` command
- keep local issue-planning/import helper files ignored from git

closes #153 
closes #154
closes #155 
closes #156  