### PR TITLE
eCc

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+- 
+
+## Testing
+
+- 
+
+## Rollout Notes
+
+- 
+
+## Follow-ups
+
+- 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing to Chordially
+
+Chordially is being developed as a production-grade open-source product. Contributors should favor small, reviewable changes that preserve a stable path toward live tipping, realtime interactivity, and operational safety.
+
+## Branch Conventions
+
+- Feature work: `feat/<short-description>`
+- Fixes: `fix/<short-description>`
+- Docs-only changes: `docs/<short-description>`
+- Chore or tooling changes: `chore/<short-description>`
+
+Use short, descriptive names such as `feat/live-session-state` or `docs/release-process`.
+
+## Commit Conventions
+
+- Keep commits small and logically scoped.
+- Prefer imperative messages:
+  - `add local bootstrap script`
+  - `document release process`
+  - `normalize package env examples`
+- Do not mix unrelated refactors into the same commit.
+
+## Pull Request Expectations
+
+- Link the issue or roadmap item being addressed.
+- Describe the user-facing or operator-facing impact.
+- Include validation notes covering automated checks and any manual verification.
+- Call out follow-up work explicitly instead of expanding scope silently.
+
+Use the repository pull request template when opening a PR.
+
+## Labels and Issue Flow
+
+Recommended labels:
+
+- `foundation`
+- `backend`
+- `web`
+- `mobile`
+- `blockchain`
+- `docs`
+- `infra`
+- `security`
+- `needs-design`
+- `good first issue`
+
+Recommended issue states:
+
+- `todo`
+- `in-progress`
+- `blocked`
+- `review-ready`
+- `done`
+
+Track these with GitHub Projects, labels, or milestones rather than relying on issue title edits.
+
+## Release Expectations
+
+- `main` should stay releasable.
+- Changes should merge through pull requests, not direct pushes.
+- Group release notes by product surface: API, web, mobile, blockchain, docs, infra.
+- Note any environment variable, migration, or operational changes in the PR description.
+
+See [docs/release-process.md](./docs/release-process.md) for the release workflow and [docs/environment-registry.md](./docs/environment-registry.md) for environment ownership.

--- a/README.md
+++ b/README.md
@@ -13,3 +13,14 @@
 - [Archive boundary](./docs/archive-boundary.md)
 - [Ownership map](./docs/ownership-map.md)
 - [Workspace scripts](./docs/workspace-scripts.md)
+- [Environment registry](./docs/environment-registry.md)
+- [Release process](./docs/release-process.md)
+- [Contribution guide](./CONTRIBUTING.md)
+
+## Local bootstrap
+
+Run the local bootstrap helper to copy env files, install dependencies, start local services, and verify the API environment contract:
+
+```bash
+node scripts/bootstrap-local.mjs
+```

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -9,12 +9,14 @@ This branch adds a standalone Express application structure that can be merged e
 
 ## Local setup
 
-1. Copy `.env.example` to `.env`
-2. Run `pnpm install` inside `apps/api`
-3. Run `pnpm check:env`
-4. Run `pnpm dev`
+1. From the repository root, run `node scripts/bootstrap-local.mjs`
+2. Or manually copy `.env.example` to `.env`
+3. Run `pnpm install` from the repository root
+4. Run `pnpm --filter @chordially/api check:env`
+5. Run `pnpm dev:api`
 
 ## Notes
 
 - Environment validation fails fast on boot so missing configuration is caught immediately.
 - The route/module layout is intentionally small and safe to extend in later issues without restructuring again.
+- Local infrastructure is provided through the repository `docker-compose.yml`.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,7 +12,9 @@
     "check:env": "tsx src/config/validate-env.ts"
   },
   "dependencies": {
-    "express": "^4.21.2"
+    "dotenv": "^16.4.7",
+    "express": "^4.21.2",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@types/express": "^5.0.1",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: chordially-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: chordially
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - chordially-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d chordially"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    container_name: chordially-redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    volumes:
+      - chordially-redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  chordially-postgres-data:
+  chordially-redis-data:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -24,6 +24,12 @@ cp apps/web/.env.example apps/web/.env.local
 cp apps/mobile/.env.example apps/mobile/.env
 ```
 
+For local setup you can also run:
+
+```bash
+node scripts/bootstrap-local.mjs
+```
+
 ---
 
 ## Environment targets
@@ -32,7 +38,8 @@ cp apps/mobile/.env.example apps/mobile/.env
 
 - API: `http://localhost:3001`
 - Stellar: `testnet`
-- Database: local Postgres (see `apps/api/.env.example`)
+- Database: local Postgres via `docker compose`
+- Cache and realtime support: local Redis via `docker compose`
 
 ### Preview / Hosted demo
 
@@ -92,3 +99,13 @@ cd apps/mobile && pnpm start
 ```
 
 Ensure each app has its `.env` (or `.env.local`) populated before starting.
+
+## Local infrastructure
+
+Start local infrastructure with:
+
+```bash
+docker compose up -d postgres redis
+```
+
+The compose file intentionally matches the current API environment example, which still uses Postgres on this branch.

--- a/docs/environment-registry.md
+++ b/docs/environment-registry.md
@@ -1,0 +1,37 @@
+# Environment Registry
+
+This document is the source of truth for runtime configuration across Chordially applications.
+
+## API
+
+| Variable | Required | Example | Owner | Notes |
+| --- | --- | --- | --- | --- |
+| `NODE_ENV` | yes | `development` | backend | One of `development`, `test`, `production` |
+| `PORT` | yes | `3001` | backend | HTTP listen port |
+| `DATABASE_URL` | yes | `postgresql://postgres:postgres@localhost:5432/chordially?schema=public` | backend | Current branch uses Postgres for local persistence |
+| `STELLAR_NETWORK` | yes | `testnet` | blockchain | One of `testnet`, `mainnet` |
+| `STELLAR_HORIZON_URL` | yes | `https://horizon-testnet.stellar.org` | blockchain | Horizon endpoint for the configured network |
+| `SESSION_SECRET` | yes | `change-me-for-local-dev` | backend | Minimum length enforced in the API env validator |
+| `ALLOWED_ORIGINS` | no | `http://localhost:3000` | backend | Comma-separated CORS allowlist for browser clients |
+| `DEMO_MODE` | no | `false` | backend | Enables mock payment fallback behavior |
+
+## Web
+
+| Variable | Required | Example | Owner | Notes |
+| --- | --- | --- | --- | --- |
+| `NEXT_PUBLIC_API_URL` | yes | `http://localhost:3001` | web | Base URL for API requests |
+| `NEXT_PUBLIC_APP_ENV` | yes | `development` | web | Environment label exposed to the client |
+
+## Mobile
+
+| Variable | Required | Example | Owner | Notes |
+| --- | --- | --- | --- | --- |
+| `EXPO_PUBLIC_API_URL` | yes | `http://localhost:3001` | mobile | Base URL for API requests |
+| `EXPO_PUBLIC_APP_ENV` | yes | `development` | mobile | Environment label exposed to the client |
+
+## Update Policy
+
+- Add new variables here in the same change that introduces them.
+- Update the relevant `.env.example` file in the same pull request.
+- Document whether the variable is local-only, preview-only, or required in production.
+- Treat undocumented environment changes as incomplete work.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,33 @@
+# Release Process
+
+This repository ships from `main` through reviewed pull requests. The process below keeps releases incremental and contributor-friendly.
+
+## Workflow
+
+1. Create a focused branch from `main`.
+2. Implement one bounded issue or a tightly-coupled batch.
+3. Run the relevant checks for the touched surfaces.
+4. Open a pull request with testing notes and rollout notes.
+5. Merge only when the branch is green and reviewer feedback is resolved.
+
+## Release Notes
+
+Every pull request should call out:
+
+- affected packages
+- new or changed environment variables
+- operational steps such as seeds, migrations, or infrastructure changes
+- user-facing behavior changes
+
+## Versioning
+
+- Use conventional, human-readable commit messages for contributor clarity.
+- Aggregate release notes by milestone or deployment window.
+- Treat incompatible environment or deployment changes as release blockers until documented.
+
+## Production Safety Checks
+
+- No direct secret values in source control.
+- No undocumented config changes.
+- No silent changes to public API shapes or shared contracts.
+- No unreviewed changes to payment or authentication flows.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "packageManager": "pnpm@10.6.5",
   "scripts": {
+    "bootstrap:local": "node scripts/bootstrap-local.mjs",
     "check": "pnpm lint && pnpm typecheck && pnpm test",
     "build": "turbo run build",
     "dev:api": "pnpm --filter @chordially/api dev",

--- a/scripts/bootstrap-local.mjs
+++ b/scripts/bootstrap-local.mjs
@@ -1,0 +1,130 @@
+import { copyFileSync, existsSync } from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const rootDir = process.cwd();
+const envTargets = [
+  {
+    source: "apps/api/.env.example",
+    target: "apps/api/.env",
+    label: "API"
+  },
+  {
+    source: "apps/web/.env.example",
+    target: "apps/web/.env.local",
+    label: "web"
+  },
+  {
+    source: "apps/mobile/.env.example",
+    target: "apps/mobile/.env",
+    label: "mobile"
+  }
+];
+
+function parseArgs(argv) {
+  return {
+    skipInstall: argv.includes("--skip-install"),
+    skipDocker: argv.includes("--skip-docker"),
+    skipChecks: argv.includes("--skip-checks"),
+    help: argv.includes("--help")
+  };
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/bootstrap-local.mjs [options]
+
+Options:
+  --skip-install    Do not run pnpm install
+  --skip-docker     Do not start docker compose services
+  --skip-checks     Do not run post-bootstrap verification commands
+  --help            Show this help text
+`);
+}
+
+function assertCommand(command, required = true) {
+  const result = spawnSync(command, ["--version"], { stdio: "ignore" });
+  if (result.status === 0) {
+    return true;
+  }
+
+  if (required) {
+    throw new Error(`Required command not found in PATH: ${command}`);
+  }
+
+  return false;
+}
+
+function ensureEnvFiles() {
+  for (const file of envTargets) {
+    const source = path.join(rootDir, file.source);
+    const target = path.join(rootDir, file.target);
+
+    if (existsSync(target)) {
+      console.log(`preserved ${file.target}`);
+      continue;
+    }
+
+    copyFileSync(source, target);
+    console.log(`created ${file.target} from ${file.source}`);
+  }
+}
+
+function runCommand(command, args, options = {}) {
+  const pretty = [command, ...args].join(" ");
+  console.log(`> ${pretty}`);
+
+  const result = spawnSync(command, args, {
+    cwd: rootDir,
+    stdio: "inherit",
+    ...options
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`Command failed: ${pretty}`);
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  assertCommand("node");
+  assertCommand("pnpm");
+
+  ensureEnvFiles();
+
+  if (!args.skipInstall) {
+    runCommand("pnpm", ["install"]);
+  }
+
+  if (!args.skipDocker) {
+    if (assertCommand("docker", false)) {
+      runCommand("docker", ["compose", "up", "-d", "postgres", "redis"]);
+    } else {
+      console.log("skipping docker compose startup because docker is not installed");
+    }
+  }
+
+  if (!args.skipChecks) {
+    runCommand("pnpm", ["--filter", "@chordially/api", "check:env"]);
+  }
+
+  console.log("");
+  console.log("Bootstrap complete.");
+  console.log("Next steps:");
+  console.log("- Start the API with `pnpm dev:api`");
+  console.log("- Start the web app with `pnpm dev:web`");
+  console.log("- Start the mobile app with `pnpm dev:mobile`");
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}


### PR DESCRIPTION
- add a one-command local bootstrap script for contributors
- document contributor branch, commit, PR, and release conventions
- add a canonical environment variable registry
- add a deterministic local Docker Compose stack for Postgres and Redis
- update the README and deployment docs to point at the new local setup flow
- fix missing API package dependencies for existing env validation imports

closes #157
closes #158
closes #159
closes #160
