### PR TITLE
Feat/redcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 
 - [Repository inventory](./docs/repository-inventory.md)
 - [Archive boundary](./docs/archive-boundary.md)
+- [API standards](./docs/api-standards.md)
+- [System context](./docs/system-context.md)
+- [Architecture decisions](./docs/decisions/README.md)
 - [Ownership map](./docs/ownership-map.md)
 - [Workspace scripts](./docs/workspace-scripts.md)
 - [Environment registry](./docs/environment-registry.md)
@@ -23,4 +26,10 @@ Run the local bootstrap helper to copy env files, install dependencies, start lo
 
 ```bash
 node scripts/bootstrap-local.mjs
+```
+
+Check repository readiness with:
+
+```bash
+node scripts/repo-health.mjs
 ```

--- a/docs/api-standards.md
+++ b/docs/api-standards.md
@@ -1,0 +1,55 @@
+# API Standards
+
+This document defines the baseline API versioning and error-envelope contract for Chordially.
+
+## Versioning Strategy
+
+- Chordially uses path-based versioning for externally consumed HTTP APIs.
+- The initial stable base path is `/api/v1`.
+- Existing unversioned phase scaffolding routes may remain temporarily during migration, but new public endpoints should be added under `/api/v1`.
+- Backward-incompatible changes require a new versioned path such as `/api/v2`.
+
+## Response Envelope
+
+Successful responses may return plain resource payloads for now, but all error responses must conform to the standard error envelope below.
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Request validation failed",
+    "details": {
+      "field": "email"
+    }
+  },
+  "meta": {
+    "requestId": "req_123",
+    "apiVersion": "v1"
+  }
+}
+```
+
+## Error Code Rules
+
+- `code` must be a stable machine-readable identifier.
+- `message` must be safe to log and safe to expose to clients.
+- `details` is optional and should only contain structured debugging context, never secrets.
+- `meta.requestId` should be propagated from request tracing middleware when available.
+- `meta.apiVersion` should reflect the versioned route namespace.
+
+## Baseline Error Codes
+
+- `VALIDATION_ERROR`
+- `UNAUTHORIZED`
+- `FORBIDDEN`
+- `NOT_FOUND`
+- `CONFLICT`
+- `RATE_LIMITED`
+- `INTERNAL_ERROR`
+- `DEPENDENCY_ERROR`
+
+## Migration Guidance
+
+- When upgrading existing routes, preserve current success payloads unless there is a compelling consumer benefit in wrapping them.
+- Normalize all new and migrated error paths to the shared envelope.
+- Publish shared response shapes through `packages/types` so clients do not re-declare them inconsistently.

--- a/docs/decisions/0000-template.md
+++ b/docs/decisions/0000-template.md
@@ -1,0 +1,26 @@
+# ADR 0000: Title
+
+- Status: Proposed
+- Date: YYYY-MM-DD
+- Owners: @maintainer
+
+## Context
+
+Describe the product, technical, or operational pressure that makes this decision necessary.
+
+## Decision
+
+State the decision clearly and directly.
+
+## Consequences
+
+List the expected benefits, tradeoffs, and follow-up work created by the decision.
+
+## Alternatives Considered
+
+- Alternative 1
+- Alternative 2
+
+## References
+
+- Relevant issue, PR, or design document

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,24 @@
+# Architecture Decisions
+
+This directory tracks Architecture Decision Records for changes that affect multiple packages, operational workflows, or long-term repository structure.
+
+## How to use ADRs
+
+- Copy [`0000-template.md`](./0000-template.md) when starting a new decision record.
+- Use a four-digit prefix such as `0001-realtime-transport.md`.
+- Keep the title short and decision-oriented.
+- Update the status when a decision moves from proposed to accepted, superseded, or deprecated.
+
+## When an ADR is required
+
+Create an ADR when a change affects:
+
+- package or service boundaries
+- persistence technology or migration strategy
+- API versioning rules or public contracts
+- realtime transport, background job, or payment architecture
+- contributor workflow conventions that materially affect the repo
+
+## Current ADR index
+
+- No accepted ADRs yet

--- a/docs/system-context.md
+++ b/docs/system-context.md
@@ -1,0 +1,72 @@
+# MVP System Context
+
+This document describes the current MVP system context for Chordially and defines the bounded contexts contributors should treat as the primary architectural seams.
+
+## System Context Diagram
+
+```mermaid
+flowchart LR
+  Fans["Fans"] --> Web["Web App"]
+  Fans --> Mobile["Mobile App"]
+  Artists["Artists"] --> Web
+  Artists --> Mobile
+  Admins["Admins"] --> Admin["Admin Surface"]
+
+  Web --> API["API Service"]
+  Mobile --> API
+  Admin --> API
+
+  API --> DB["Primary Data Store"]
+  API --> Redis["Redis"]
+  API --> Stellar["Stellar / Horizon"]
+  API --> Storage["Media Storage"]
+```
+
+## Primary Actors
+
+- Fans discover live sessions, join them, and send tips.
+- Artists manage profiles, start sessions, and monitor earnings.
+- Admins moderate users, sessions, and transactions.
+
+## Bounded Contexts
+
+### Identity and Access
+
+- registration, login, session validation, role enforcement
+- owned primarily by API and consumed by web, mobile, and admin surfaces
+
+### Artist Profile
+
+- public performer identity, profile media, onboarding state, payout readiness
+- consumed by discovery, session, and admin contexts
+
+### Live Session
+
+- draft, scheduled, live, paused, ended session lifecycle
+- exposes live status and runtime metrics to clients and admin tooling
+
+### Realtime Interaction
+
+- viewer presence, activity feeds, reactions, leaderboards, moment updates
+- built on Redis-backed fanout and client subscriptions
+
+### Payments and Settlement
+
+- tip intents, transaction preparation, verification, settlement, earnings aggregation
+- integrates with Stellar but exposes stable product-level state internally
+
+### Discovery and Growth
+
+- live feed ranking, personalization, badges, streaks, and supporter identity surfaces
+- consumes artist, session, and payment signals but should remain read-optimized
+
+### Admin Operations
+
+- moderation, transaction review, audit queries, and operational overrides
+- must remain isolated from consumer-facing mutation flows
+
+## Context Boundaries
+
+- Shared types belong in `packages/types`.
+- External-provider specifics should stay behind service adapters in package or app internals.
+- Cross-context interactions should happen through stable API contracts or documented domain events rather than direct file reuse.

--- a/docs/workspace-scripts.md
+++ b/docs/workspace-scripts.md
@@ -12,6 +12,7 @@ Chordially uses a small shared script vocabulary across packages so contributors
 | `typecheck` | Run TypeScript type validation for the package |
 | `test` | Run the package's automated test suite or a documented no-op placeholder |
 | `check:env` | Validate required environment variables for runnable applications |
+| `repo:health` | Report repository readiness, env-file presence, and local service status |
 
 ## Current Policy
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev:web": "pnpm --filter @chordially/web dev",
     "dev:mobile": "pnpm --filter @chordially/mobile dev",
     "lint": "eslint .",
+    "repo:health": "node scripts/repo-health.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "turbo run test",
     "dev": "turbo run dev --parallel"

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -28,3 +28,27 @@ export interface SessionResponse {
   authenticated: boolean;
   user: AuthUser | null;
 }
+
+export type ApiErrorCode =
+  | "VALIDATION_ERROR"
+  | "UNAUTHORIZED"
+  | "FORBIDDEN"
+  | "NOT_FOUND"
+  | "CONFLICT"
+  | "RATE_LIMITED"
+  | "INTERNAL_ERROR"
+  | "DEPENDENCY_ERROR";
+
+export interface ApiErrorEnvelope {
+  error: {
+    code: ApiErrorCode;
+    message: string;
+    details?: unknown;
+  };
+  meta: {
+    requestId?: string;
+    apiVersion: string;
+  };
+}
+
+export const API_V1_PREFIX = "/api/v1";

--- a/scripts/repo-health.mjs
+++ b/scripts/repo-health.mjs
@@ -1,0 +1,128 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const rootDir = process.cwd();
+
+function commandAvailable(command) {
+  const result = spawnSync(command, ["--version"], { stdio: "ignore" });
+  return result.status === 0;
+}
+
+function readJson(relativePath) {
+  return JSON.parse(readFileSync(path.join(rootDir, relativePath), "utf8"));
+}
+
+function checkEnvFiles() {
+  return [
+    ["apps/api/.env", existsSync(path.join(rootDir, "apps/api/.env"))],
+    ["apps/web/.env.local", existsSync(path.join(rootDir, "apps/web/.env.local"))],
+    ["apps/mobile/.env", existsSync(path.join(rootDir, "apps/mobile/.env"))]
+  ];
+}
+
+function workspaceScripts() {
+  const files = [
+    "package.json",
+    "apps/api/package.json",
+    "apps/web/package.json",
+    "apps/mobile/package.json"
+  ];
+
+  return files.map((file) => {
+    const json = readJson(file);
+    return {
+      file,
+      scripts: Object.keys(json.scripts ?? {}).sort()
+    };
+  });
+}
+
+function gitSummary() {
+  const branch = spawnSync("git", ["branch", "--show-current"], { encoding: "utf8" });
+  const status = spawnSync("git", ["status", "--short"], { encoding: "utf8" });
+
+  return {
+    branch: branch.stdout.trim() || "unknown",
+    clean: status.stdout.trim().length === 0
+  };
+}
+
+function dockerSummary() {
+  if (!commandAvailable("docker")) {
+    return { available: false };
+  }
+
+  const result = spawnSync("docker", ["compose", "ps", "--format", "json"], {
+    cwd: rootDir,
+    encoding: "utf8"
+  });
+
+  if (result.status !== 0) {
+    return { available: true, running: false };
+  }
+
+  const lines = result.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+
+  return {
+    available: true,
+    running: lines.length > 0,
+    services: lines.map((entry) => ({
+      service: entry.Service,
+      state: entry.State
+    }))
+  };
+}
+
+function printSection(title, lines) {
+  console.log(title);
+  for (const line of lines) {
+    console.log(`- ${line}`);
+  }
+  console.log("");
+}
+
+function main() {
+  const git = gitSummary();
+  const envFiles = checkEnvFiles();
+  const scripts = workspaceScripts();
+  const docker = dockerSummary();
+
+  printSection("Repository", [
+    `branch: ${git.branch}`,
+    `working tree clean: ${git.clean ? "yes" : "no"}`,
+    `node available: ${commandAvailable("node") ? "yes" : "no"}`,
+    `pnpm available: ${commandAvailable("pnpm") ? "yes" : "no"}`
+  ]);
+
+  printSection(
+    "Environment files",
+    envFiles.map(([file, exists]) => `${file}: ${exists ? "present" : "missing"}`)
+  );
+
+  printSection(
+    "Workspace scripts",
+    scripts.map(({ file, scripts: packageScripts }) => `${file}: ${packageScripts.join(", ")}`)
+  );
+
+  if (!docker.available) {
+    printSection("Docker", ["docker is not installed"]);
+    return;
+  }
+
+  if (!docker.running) {
+    printSection("Docker", ["docker compose is available but no services are currently running"]);
+    return;
+  }
+
+  printSection(
+    "Docker",
+    docker.services.map((service) => `${service.service}: ${service.state}`)
+  );
+}
+
+main();


### PR DESCRIPTION

- add a repository health command for local readiness checks
- add ADR scaffolding and an architecture decision index
- document the MVP system context and bounded contexts
- define baseline API versioning and error-envelope standards
- publish shared API error types for downstream consumers
- link the new architecture standards from the README and workspace scripts docs

closes #161
closes #162
closes #163
closes #164