### PR TITLE
feat: backend module template, domain glossary, data ownership, and NFR budgets

### DIFF
--- a/apps/api/src/config/dataOwnership.ts
+++ b/apps/api/src/config/dataOwnership.ts
@@ -1,0 +1,38 @@
+/**
+ * CHORD-015 — Data Ownership Boundaries
+ * Defines which store is the authoritative source of truth for each data class.
+ */
+
+export type DataStore = "mongodb" | "redis" | "blockchain";
+
+export interface OwnershipRule {
+  entity: string;
+  owner: DataStore;
+  /** Stores that may hold a derived/cached copy — never written to directly. */
+  caches: DataStore[];
+  ttlSeconds?: number;
+}
+
+export const DATA_OWNERSHIP: OwnershipRule[] = [
+  { entity: "UserProfile",      owner: "mongodb",     caches: ["redis"],       ttlSeconds: 300 },
+  { entity: "ArtistBalance",    owner: "blockchain",  caches: ["redis"],       ttlSeconds: 30  },
+  { entity: "SessionState",     owner: "redis",       caches: [],              ttlSeconds: 3600 },
+  { entity: "TipTransaction",   owner: "blockchain",  caches: ["mongodb"],                      },
+  { entity: "Leaderboard",      owner: "redis",       caches: [],              ttlSeconds: 60  },
+  { entity: "BackstagePassNFT", owner: "blockchain",  caches: ["mongodb"],                      },
+  { entity: "AuditLog",         owner: "mongodb",     caches: [],                               },
+];
+
+/** Returns the authoritative store for a given entity name. */
+export function getOwner(entity: string): DataStore {
+  const rule = DATA_OWNERSHIP.find((r) => r.entity === entity);
+  if (!rule) throw new Error(`No ownership rule defined for entity: ${entity}`);
+  return rule.owner;
+}
+
+/** Returns true if the given store is allowed to serve reads for an entity. */
+export function canRead(entity: string, store: DataStore): boolean {
+  const rule = DATA_OWNERSHIP.find((r) => r.entity === entity);
+  if (!rule) return false;
+  return rule.owner === store || rule.caches.includes(store);
+}

--- a/apps/api/src/config/nfr.ts
+++ b/apps/api/src/config/nfr.ts
@@ -1,0 +1,56 @@
+/**
+ * CHORD-016 — Non-Functional Requirements: Latency, Uptime & Transaction Reliability
+ * Versioned budgets consumed by health checks, load tests, and alerting rules.
+ */
+
+export const NFR_VERSION = "1.0.0";
+
+export interface LatencyBudget {
+  p50Ms: number;
+  p95Ms: number;
+  p99Ms: number;
+}
+
+export interface UptimeBudget {
+  targetPercent: number;   // e.g. 99.9
+  maxMonthlyDowntimeMin: number;
+}
+
+export interface TxReliabilityBudget {
+  confirmationMaxMs: number;
+  maxRetries: number;
+  successRatePercent: number;
+}
+
+export const LATENCY: Record<string, LatencyBudget> = {
+  apiResponse:      { p50Ms: 80,   p95Ms: 200,  p99Ms: 500  },
+  socketFanout:     { p50Ms: 50,   p95Ms: 120,  p99Ms: 300  },
+  tipConfirmation:  { p50Ms: 3000, p95Ms: 6000, p99Ms: 10000 },
+  pageLoad:         { p50Ms: 1500, p95Ms: 3000, p99Ms: 5000  },
+};
+
+export const UPTIME: UptimeBudget = {
+  targetPercent: 99.9,
+  maxMonthlyDowntimeMin: 43,
+};
+
+export const TX_RELIABILITY: TxReliabilityBudget = {
+  confirmationMaxMs: 10_000,
+  maxRetries: 3,
+  successRatePercent: 99.5,
+};
+
+/** Validates a measured value against a named latency budget key and percentile. */
+export function assertLatency(
+  key: keyof typeof LATENCY,
+  percentile: "p50Ms" | "p95Ms" | "p99Ms",
+  measuredMs: number
+): void {
+  const budget = LATENCY[key];
+  if (!budget) throw new Error(`Unknown latency key: ${key}`);
+  if (measuredMs > budget[percentile]) {
+    throw new Error(
+      `Latency breach: ${key} ${percentile} ${measuredMs}ms > budget ${budget[percentile]}ms`
+    );
+  }
+}

--- a/apps/api/src/templates/moduleTemplate.ts
+++ b/apps/api/src/templates/moduleTemplate.ts
@@ -1,0 +1,62 @@
+import { Router, Request, Response, NextFunction } from "express";
+
+// ── Schema ────────────────────────────────────────────────────────────────────
+export interface DomainEntity {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+// ── Repository ────────────────────────────────────────────────────────────────
+export interface Repository<T extends DomainEntity> {
+  findById(id: string): Promise<T | null>;
+  findAll(): Promise<T[]>;
+  save(entity: Omit<T, "id" | "createdAt" | "updatedAt">): Promise<T>;
+  delete(id: string): Promise<void>;
+}
+
+// ── Service ───────────────────────────────────────────────────────────────────
+export abstract class BaseService<T extends DomainEntity> {
+  constructor(protected readonly repo: Repository<T>) {}
+
+  async getById(id: string): Promise<T> {
+    const entity = await this.repo.findById(id);
+    if (!entity) throw Object.assign(new Error("Not found"), { status: 404 });
+    return entity;
+  }
+
+  async list(): Promise<T[]> {
+    return this.repo.findAll();
+  }
+}
+
+// ── Controller ────────────────────────────────────────────────────────────────
+export abstract class BaseController<T extends DomainEntity> {
+  constructor(protected readonly service: BaseService<T>) {}
+
+  getOne = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      res.json(await this.service.getById(req.params.id));
+    } catch (err) {
+      next(err);
+    }
+  };
+
+  getAll = async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+      res.json(await this.service.list());
+    } catch (err) {
+      next(err);
+    }
+  };
+}
+
+// ── Router factory ────────────────────────────────────────────────────────────
+export function createModuleRouter<T extends DomainEntity>(
+  controller: BaseController<T>
+): Router {
+  const router = Router();
+  router.get("/", controller.getAll);
+  router.get("/:id", controller.getOne);
+  return router;
+}

--- a/packages/types/src/glossary.ts
+++ b/packages/types/src/glossary.ts
@@ -1,0 +1,53 @@
+/**
+ * Chordially Domain Glossary — CHORD-014
+ * Single source of truth for core terminology across product, engineering, and blockchain layers.
+ */
+
+/** A registered creator who can open live sessions and receive tips. */
+export interface Artist {
+  id: string;
+  stellarPublicKey: string;
+  displayName: string;
+  genre: string[];
+}
+
+/** A registered supporter who can join sessions and send tips. */
+export interface Fan {
+  id: string;
+  stellarPublicKey: string;
+  username: string;
+  backstagePasses: string[]; // NFT asset codes
+}
+
+/** A live-streaming event opened by an Artist. */
+export interface Session {
+  id: string;
+  artistId: string;
+  startedAt: Date;
+  endedAt?: Date;
+  status: "live" | "ended" | "scheduled";
+}
+
+/** A discrete highlight within a Session (e.g. a song, a speech). */
+export interface Moment {
+  id: string;
+  sessionId: string;
+  label: string;
+  timestampMs: number;
+}
+
+/** A micro-payment sent by a Fan to an Artist during a Session. */
+export interface Tip {
+  id: string;
+  sessionId: string;
+  fanId: string;
+  artistId: string;
+  amountXLM: number;
+  assetCode: "XLM" | "USDC";
+  stellarTxHash: string;
+  confirmedAt: Date;
+}
+
+/** Mapping of domain terms to their canonical type for runtime validation. */
+export const DOMAIN_TERMS = ["Artist", "Fan", "Session", "Moment", "Tip"] as const;
+export type DomainTerm = (typeof DOMAIN_TERMS)[number];


### PR DESCRIPTION
Closes #165, closes #166, closes #167, closes #168

- **CHORD-013** – adds `moduleTemplate.ts`: a typed Router/Controller/Service/Repository base that new Express domains extend.
- **CHORD-014** – adds `glossary.ts` in `packages/types`: canonical TS interfaces for Artist, Fan, Session, Moment, and Tip.
- **CHORD-015** – adds `dataOwnership.ts`: ownership rules table mapping each entity to its authoritative store (MongoDB / Redis / blockchain) with cache and TTL metadata.
- **CHORD-016** – adds `nfr.ts`: versioned latency budgets (p50/p95/p99), uptime SLO, and transaction reliability targets with a runtime assertion helper.