### PR TITLE
feat: backend platform hardening (CHORD-025–028)

### DIFF
--- a/apps/api/src/lib/graceful-shutdown.ts
+++ b/apps/api/src/lib/graceful-shutdown.ts
@@ -1,0 +1,59 @@
+import type { Server } from "http";
+import type { Server as SocketServer } from "socket.io";
+
+interface ShutdownDeps {
+  httpServer: Server;
+  io?: SocketServer;
+  redisQuit?: () => Promise<void>;
+  dbDisconnect?: () => Promise<void>;
+}
+
+const DRAIN_TIMEOUT_MS = 10_000;
+
+export function registerGracefulShutdown(deps: ShutdownDeps): void {
+  let isShuttingDown = false;
+
+  async function shutdown(signal: string): Promise<void> {
+    if (isShuttingDown) return;
+    isShuttingDown = true;
+    console.log(`[shutdown] received ${signal}, draining connections…`);
+
+    const timer = setTimeout(() => {
+      console.error("[shutdown] drain timeout exceeded, forcing exit");
+      process.exit(1);
+    }, DRAIN_TIMEOUT_MS);
+
+    try {
+      await new Promise<void>((resolve, reject) =>
+        deps.httpServer.close((err) => (err ? reject(err) : resolve()))
+      );
+      console.log("[shutdown] HTTP server closed");
+
+      if (deps.io) {
+        await new Promise<void>((resolve) => deps.io!.close(() => resolve()));
+        console.log("[shutdown] Socket.IO closed");
+      }
+
+      if (deps.redisQuit) {
+        await deps.redisQuit();
+        console.log("[shutdown] Redis disconnected");
+      }
+
+      if (deps.dbDisconnect) {
+        await deps.dbDisconnect();
+        console.log("[shutdown] DB disconnected");
+      }
+
+      clearTimeout(timer);
+      console.log("[shutdown] clean exit");
+      process.exit(0);
+    } catch (err) {
+      console.error("[shutdown] error during drain", err);
+      clearTimeout(timer);
+      process.exit(1);
+    }
+  }
+
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  process.on("SIGINT", () => shutdown("SIGINT"));
+}

--- a/apps/api/src/middleware/anti-abuse.ts
+++ b/apps/api/src/middleware/anti-abuse.ts
@@ -1,0 +1,56 @@
+import type { Request, Response, NextFunction, RequestHandler } from "express";
+
+const BLOCKED_UA_PATTERNS = [/sqlmap/i, /nikto/i, /masscan/i, /zgrab/i];
+const SUSPICIOUS_PAYLOAD_KEYS = ["$where", "__proto__", "constructor", "eval("];
+
+function hasSuspiciousPayload(obj: unknown, depth = 0): boolean {
+  if (depth > 5 || typeof obj !== "object" || obj === null) return false;
+  return Object.keys(obj as Record<string, unknown>).some(
+    (k) =>
+      SUSPICIOUS_PAYLOAD_KEYS.some((p) => k.includes(p)) ||
+      hasSuspiciousPayload((obj as Record<string, unknown>)[k], depth + 1)
+  );
+}
+
+function isBlockedUserAgent(ua: string | undefined): boolean {
+  if (!ua) return false;
+  return BLOCKED_UA_PATTERNS.some((p) => p.test(ua));
+}
+
+function logAbuse(req: Request, reason: string): void {
+  console.warn("[anti-abuse]", {
+    reason,
+    ip: req.ip,
+    method: req.method,
+    path: req.path,
+    ua: req.headers["user-agent"],
+    ts: new Date().toISOString(),
+  });
+}
+
+export const antiAbuseMiddleware: RequestHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
+  if (isBlockedUserAgent(req.headers["user-agent"])) {
+    logAbuse(req, "blocked-user-agent");
+    res.status(403).json({ error: "Forbidden" });
+    return;
+  }
+
+  if (hasSuspiciousPayload(req.body)) {
+    logAbuse(req, "suspicious-payload");
+    res.status(400).json({ error: "Invalid request payload" });
+    return;
+  }
+
+  const contentLength = parseInt(req.headers["content-length"] ?? "0", 10);
+  if (contentLength > 1_000_000) {
+    logAbuse(req, "oversized-payload");
+    res.status(413).json({ error: "Payload too large" });
+    return;
+  }
+
+  next();
+};

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -1,0 +1,39 @@
+import rateLimit from "express-rate-limit";
+import type { RequestHandler } from "express";
+
+interface RateLimitOptions {
+  windowMs?: number;
+  max?: number;
+  message?: string;
+}
+
+function makeRateLimiter(opts: RateLimitOptions): RequestHandler {
+  return rateLimit({
+    windowMs: opts.windowMs ?? 15 * 60 * 1000,
+    max: opts.max ?? 100,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: opts.message ?? "Too many requests, please try again later." },
+    skip: (req) => req.ip === "127.0.0.1" && process.env.NODE_ENV === "test",
+  });
+}
+
+/** Strict limiter for login / register — 10 attempts per 15 min per IP */
+export const authRateLimiter: RequestHandler = makeRateLimiter({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  message: "Too many auth attempts. Please wait before trying again.",
+});
+
+/** Moderate limiter for state-mutating routes (tips, profile updates) */
+export const mutationRateLimiter: RequestHandler = makeRateLimiter({
+  windowMs: 60 * 1000,
+  max: 30,
+  message: "Too many requests. Slow down.",
+});
+
+/** Loose limiter for general API surface */
+export const globalRateLimiter: RequestHandler = makeRateLimiter({
+  windowMs: 60 * 1000,
+  max: 120,
+});

--- a/apps/api/src/modules/health/diagnostics.routes.ts
+++ b/apps/api/src/modules/health/diagnostics.routes.ts
@@ -1,0 +1,60 @@
+import { Router, type Request, type Response } from "express";
+
+const router = Router();
+
+interface DepCheck {
+  name: string;
+  check: () => Promise<boolean>;
+}
+
+const deps: DepCheck[] = [];
+
+export function registerDependency(name: string, check: () => Promise<boolean>): void {
+  deps.push({ name, check });
+}
+
+/** GET /health — liveness probe: is the process alive? */
+router.get("/health", (_req: Request, res: Response): void => {
+  res.json({ status: "ok", ts: new Date().toISOString() });
+});
+
+/** GET /health/ready — readiness probe: are all deps up? */
+router.get("/health/ready", async (_req: Request, res: Response): Promise<void> => {
+  const results = await Promise.all(
+    deps.map(async ({ name, check }) => {
+      try {
+        const ok = await check();
+        return { name, status: ok ? "ok" : "degraded" };
+      } catch {
+        return { name, status: "error" };
+      }
+    })
+  );
+
+  const allOk = results.every((r) => r.status === "ok");
+  res.status(allOk ? 200 : 503).json({
+    ready: allOk,
+    dependencies: results,
+    ts: new Date().toISOString(),
+  });
+});
+
+/** GET /health/diagnostics — detailed dependency info (internal use) */
+router.get("/health/diagnostics", async (_req: Request, res: Response): Promise<void> => {
+  const start = Date.now();
+  const checks = await Promise.all(
+    deps.map(async ({ name, check }) => {
+      const t0 = Date.now();
+      try {
+        const ok = await check();
+        return { name, status: ok ? "ok" : "degraded", latencyMs: Date.now() - t0 };
+      } catch (err) {
+        return { name, status: "error", latencyMs: Date.now() - t0, error: String(err) };
+      }
+    })
+  );
+
+  res.json({ uptime: process.uptime(), totalMs: Date.now() - start, checks });
+});
+
+export { router as healthRouter };


### PR DESCRIPTION
Implements four backend hardening tasks from sprint-1:

- **CHORD-025** — graceful shutdown that drains HTTP, Socket.IO, Redis, and DB connections before exit with a 10s timeout guard
- **CHORD-026** — rate limiting middleware with separate limiters for auth (10 req/15 min), mutations (30 req/min), and global traffic
- **CHORD-027** — anti-abuse middleware blocking known scanner UAs, suspicious payload keys (proto pollution, NoSQL injection), and oversized bodies
- **CHORD-028** — `/health`, `/health/ready`, and `/health/diagnostics` endpoints with pluggable dependency checks and latency reporting

Closes #177, closes #178, closes #179, closes #180