### PR TITLE
feat: CHORD-029–032 OpenAPI gen, smoke tests, Mongo models, User schema

### DIFF
--- a/apps/api/src/lib/mongo-data-model.ts
+++ b/apps/api/src/lib/mongo-data-model.ts
@@ -1,0 +1,55 @@
+import { Schema, model, Document, Types } from 'mongoose';
+
+// ---------------------------------------------------------------------------
+// Track
+// ---------------------------------------------------------------------------
+export interface ITrack extends Document {
+  title: string;
+  artistId: Types.ObjectId;
+  durationMs: number;
+  audioUrl: string;
+  plays: number;
+  createdAt: Date;
+}
+
+const trackSchema = new Schema<ITrack>(
+  {
+    title:      { type: String, required: true, trim: true },
+    artistId:   { type: Schema.Types.ObjectId, ref: 'User', required: true, index: true },
+    durationMs: { type: Number, required: true, min: 0 },
+    audioUrl:   { type: String, required: true },
+    plays:      { type: Number, default: 0, min: 0 },
+  },
+  { timestamps: true }
+);
+
+trackSchema.index({ artistId: 1, createdAt: -1 });
+
+export const Track = model<ITrack>('Track', trackSchema);
+
+// ---------------------------------------------------------------------------
+// Tip
+// ---------------------------------------------------------------------------
+export interface ITip extends Document {
+  fromUserId: Types.ObjectId;
+  toArtistId: Types.ObjectId;
+  trackId?: Types.ObjectId;
+  amountCents: number;
+  currency: string;
+  status: 'pending' | 'settled' | 'failed';
+  createdAt: Date;
+}
+
+const tipSchema = new Schema<ITip>(
+  {
+    fromUserId:  { type: Schema.Types.ObjectId, ref: 'User', required: true, index: true },
+    toArtistId:  { type: Schema.Types.ObjectId, ref: 'User', required: true, index: true },
+    trackId:     { type: Schema.Types.ObjectId, ref: 'Track' },
+    amountCents: { type: Number, required: true, min: 1 },
+    currency:    { type: String, default: 'USD', uppercase: true, length: 3 },
+    status:      { type: String, enum: ['pending', 'settled', 'failed'], default: 'pending' },
+  },
+  { timestamps: true }
+);
+
+export const Tip = model<ITip>('Tip', tipSchema);

--- a/apps/api/src/lib/openapi-generator.ts
+++ b/apps/api/src/lib/openapi-generator.ts
@@ -1,0 +1,62 @@
+import { Router } from 'express';
+
+interface RouteContract {
+  method: string;
+  path: string;
+  summary: string;
+  tags: string[];
+  responses: Record<number, { description: string }>;
+}
+
+const registeredContracts: RouteContract[] = [];
+
+export function registerContract(contract: RouteContract): void {
+  registeredContracts.push(contract);
+}
+
+export function generateOpenApiSpec(version = '1.0.0') {
+  return {
+    openapi: '3.0.3',
+    info: { title: 'Chordially API', version },
+    paths: registeredContracts.reduce<Record<string, unknown>>((acc, c) => {
+      acc[c.path] = {
+        ...((acc[c.path] as object) ?? {}),
+        [c.method.toLowerCase()]: {
+          summary: c.summary,
+          tags: c.tags,
+          responses: Object.fromEntries(
+            Object.entries(c.responses).map(([code, val]) => [code, val])
+          ),
+        },
+      };
+      return acc;
+    }, {}),
+  };
+}
+
+export function openApiRouter(): Router {
+  const router = Router();
+
+  router.get('/openapi.json', (_req, res) => {
+    res.json(generateOpenApiSpec());
+  });
+
+  return router;
+}
+
+// Seed a few baseline contracts so the spec is non-empty on first boot
+registerContract({
+  method: 'GET',
+  path: '/health',
+  summary: 'Liveness probe',
+  tags: ['platform'],
+  responses: { 200: { description: 'OK' } },
+});
+
+registerContract({
+  method: 'GET',
+  path: '/ready',
+  summary: 'Readiness probe',
+  tags: ['platform'],
+  responses: { 200: { description: 'Ready' }, 503: { description: 'Not ready' } },
+});

--- a/apps/api/src/lib/smoke-test.ts
+++ b/apps/api/src/lib/smoke-test.ts
@@ -1,0 +1,57 @@
+import https from 'node:https';
+import http from 'node:http';
+
+const BASE_URL = process.env.SMOKE_TARGET ?? 'http://localhost:3000';
+
+interface SmokeResult {
+  route: string;
+  status: number;
+  ok: boolean;
+  ms: number;
+}
+
+function get(url: string, token?: string): Promise<{ status: number }> {
+  return new Promise((resolve, reject) => {
+    const lib = url.startsWith('https') ? https : http;
+    const req = lib.get(url, { headers: token ? { Authorization: `Bearer ${token}` } : {} }, (res) => {
+      res.resume();
+      resolve({ status: res.statusCode ?? 0 });
+    });
+    req.on('error', reject);
+    req.setTimeout(5000, () => { req.destroy(new Error('timeout')); });
+  });
+}
+
+async function probe(route: string, token?: string): Promise<SmokeResult> {
+  const start = Date.now();
+  const { status } = await get(`${BASE_URL}${route}`, token);
+  return { route, status, ok: status >= 200 && status < 400, ms: Date.now() - start };
+}
+
+export async function runSmoke(): Promise<void> {
+  const token = process.env.SMOKE_TOKEN;
+
+  const checks = await Promise.all([
+    probe('/health'),
+    probe('/ready'),
+    probe('/api/v1/profile', token),
+  ]);
+
+  let failed = 0;
+  for (const r of checks) {
+    const icon = r.ok ? '✓' : '✗';
+    console.log(`${icon}  ${r.route}  →  ${r.status}  (${r.ms}ms)`);
+    if (!r.ok) failed++;
+  }
+
+  if (failed > 0) {
+    console.error(`\n${failed} check(s) failed`);
+    process.exit(1);
+  }
+
+  console.log('\nAll smoke checks passed');
+}
+
+if (require.main === module) {
+  runSmoke().catch((err) => { console.error(err); process.exit(1); });
+}

--- a/apps/api/src/lib/user-schema.ts
+++ b/apps/api/src/lib/user-schema.ts
@@ -1,0 +1,45 @@
+import { Schema, model, Document } from 'mongoose';
+
+export type UserRole = 'fan' | 'artist' | 'admin';
+export type ConsentState = 'pending' | 'accepted' | 'withdrawn';
+export type ModerationStatus = 'active' | 'warned' | 'suspended' | 'banned';
+
+export interface IUser extends Document {
+  email: string;
+  authId: string;           // external auth provider subject (e.g. Clerk userId)
+  role: UserRole;
+  displayName: string;
+  avatarUrl?: string;
+  consentState: ConsentState;
+  consentUpdatedAt?: Date;
+  moderationStatus: ModerationStatus;
+  profileRef?: string;      // slug or ObjectId of role-specific profile doc
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const userSchema = new Schema<IUser>(
+  {
+    email:            { type: String, required: true, unique: true, lowercase: true, trim: true },
+    authId:           { type: String, required: true, unique: true, index: true },
+    role:             { type: String, enum: ['fan', 'artist', 'admin'], required: true },
+    displayName:      { type: String, required: true, trim: true, maxlength: 64 },
+    avatarUrl:        { type: String },
+    consentState:     { type: String, enum: ['pending', 'accepted', 'withdrawn'], default: 'pending' },
+    consentUpdatedAt: { type: Date },
+    moderationStatus: { type: String, enum: ['active', 'warned', 'suspended', 'banned'], default: 'active' },
+    profileRef:       { type: String },
+  },
+  { timestamps: true }
+);
+
+userSchema.index({ role: 1, moderationStatus: 1 });
+
+userSchema.pre('save', function (next) {
+  if (this.isModified('consentState')) {
+    this.consentUpdatedAt = new Date();
+  }
+  next();
+});
+
+export const User = model<IUser>('User', userSchema);


### PR DESCRIPTION
Closes #181, closes #182, closes #183, closes #184

- **CHORD-029** – `openapi-generator.ts`: builds an OpenAPI 3.0 spec from registered route contracts and exposes it at `GET /openapi.json`.
- **CHORD-030** – `smoke-test.ts`: probes `/health`, `/ready`, and `/api/v1/profile` against a configurable target; exits non-zero on any failure.
- **CHORD-031** – `mongo-data-model.ts`: authoritative Mongoose schemas for `Track` and `Tip`, replacing the Prisma prototype with indexed, document-first models.
- **CHORD-032** – `user-schema.ts`: canonical `User` schema covering fan/artist/admin roles, auth identifiers, consent state, and moderation status.