### PR TITLE
feat: MongoDB schemas for CHORD-033 to CHORD-036

### DIFF
--- a/apps/api/src/lib/artist-profile-schema.ts
+++ b/apps/api/src/lib/artist-profile-schema.ts
@@ -1,0 +1,44 @@
+import { Schema, model, Document } from 'mongoose';
+
+export type PayoutStatus = 'unverified' | 'pending' | 'verified' | 'suspended';
+
+export interface IArtistProfile extends Document {
+  userId: string;
+  slug: string;
+  displayName: string;
+  bio?: string;
+  avatarUrl?: string;
+  genres: string[];
+  isVerified: boolean;
+  payoutStatus: PayoutStatus;
+  payoutWalletAddress?: string;
+  followerCount: number;
+  totalTipsReceived: number;
+  socialLinks: Record<string, string>;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const artistProfileSchema = new Schema<IArtistProfile>(
+  {
+    userId:               { type: String, required: true, unique: true, index: true },
+    slug:                 { type: String, required: true, unique: true, lowercase: true, trim: true },
+    displayName:          { type: String, required: true, trim: true, maxlength: 64 },
+    bio:                  { type: String, maxlength: 500 },
+    avatarUrl:            { type: String },
+    genres:               { type: [String], default: [] },
+    isVerified:           { type: Boolean, default: false },
+    payoutStatus:         { type: String, enum: ['unverified', 'pending', 'verified', 'suspended'], default: 'unverified' },
+    payoutWalletAddress:  { type: String },
+    followerCount:        { type: Number, default: 0, min: 0 },
+    totalTipsReceived:    { type: Number, default: 0, min: 0 },
+    socialLinks:          { type: Map, of: String, default: {} },
+  },
+  { timestamps: true }
+);
+
+artistProfileSchema.index({ genres: 1, isVerified: 1 });
+artistProfileSchema.index({ payoutStatus: 1 });
+artistProfileSchema.index({ followerCount: -1 });
+
+export const ArtistProfile = model<IArtistProfile>('ArtistProfile', artistProfileSchema);

--- a/apps/api/src/lib/interactive-schemas.ts
+++ b/apps/api/src/lib/interactive-schemas.ts
@@ -1,0 +1,73 @@
+import { Schema, model, Document } from 'mongoose';
+
+export type MomentType = 'highlight' | 'milestone' | 'custom';
+export type UnlockState = 'locked' | 'unlocked' | 'expired';
+
+export interface IMoment extends Document {
+  sessionId: string;
+  artistId: string;
+  type: MomentType;
+  label: string;
+  timestampMs: number;
+  voteCount: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface IVote extends Document {
+  momentId: string;
+  fanId: string;
+  sessionId: string;
+  createdAt: Date;
+}
+
+export interface IUnlock extends Document {
+  sessionId: string;
+  fanId: string;
+  featureKey: string;
+  state: UnlockState;
+  unlockedAt?: Date;
+  expiresAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const momentSchema = new Schema<IMoment>(
+  {
+    sessionId:   { type: String, required: true, index: true },
+    artistId:    { type: String, required: true, index: true },
+    type:        { type: String, enum: ['highlight', 'milestone', 'custom'], required: true },
+    label:       { type: String, required: true, maxlength: 128 },
+    timestampMs: { type: Number, required: true, min: 0 },
+    voteCount:   { type: Number, default: 0, min: 0 },
+  },
+  { timestamps: true }
+);
+
+const voteSchema = new Schema<IVote>(
+  {
+    momentId:  { type: String, required: true, index: true },
+    fanId:     { type: String, required: true },
+    sessionId: { type: String, required: true, index: true },
+  },
+  { timestamps: { createdAt: true, updatedAt: false } }
+);
+
+const unlockSchema = new Schema<IUnlock>(
+  {
+    sessionId:  { type: String, required: true, index: true },
+    fanId:      { type: String, required: true, index: true },
+    featureKey: { type: String, required: true },
+    state:      { type: String, enum: ['locked', 'unlocked', 'expired'], default: 'locked' },
+    unlockedAt: { type: Date },
+    expiresAt:  { type: Date },
+  },
+  { timestamps: true }
+);
+
+voteSchema.index({ momentId: 1, fanId: 1 }, { unique: true });
+unlockSchema.index({ fanId: 1, featureKey: 1, sessionId: 1 }, { unique: true });
+
+export const Moment = model<IMoment>('Moment', momentSchema);
+export const Vote = model<IVote>('Vote', voteSchema);
+export const Unlock = model<IUnlock>('Unlock', unlockSchema);

--- a/apps/api/src/lib/session-schema.ts
+++ b/apps/api/src/lib/session-schema.ts
@@ -1,0 +1,51 @@
+import { Schema, model, Document } from 'mongoose';
+
+export type SessionState = 'draft' | 'live' | 'ended' | 'cancelled';
+
+export interface ISession extends Document {
+  artistId: string;
+  title: string;
+  description?: string;
+  state: SessionState;
+  scheduledAt?: Date;
+  startedAt?: Date;
+  endedAt?: Date;
+  cancelledAt?: Date;
+  cancelReason?: string;
+  peakViewerCount: number;
+  totalViewerCount: number;
+  totalTipsReceived: number;
+  streamKey?: string;
+  playbackUrl?: string;
+  thumbnailUrl?: string;
+  tags: string[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const sessionSchema = new Schema<ISession>(
+  {
+    artistId:          { type: String, required: true, index: true },
+    title:             { type: String, required: true, trim: true, maxlength: 120 },
+    description:       { type: String, maxlength: 1000 },
+    state:             { type: String, enum: ['draft', 'live', 'ended', 'cancelled'], default: 'draft' },
+    scheduledAt:       { type: Date },
+    startedAt:         { type: Date },
+    endedAt:           { type: Date },
+    cancelledAt:       { type: Date },
+    cancelReason:      { type: String, maxlength: 256 },
+    peakViewerCount:   { type: Number, default: 0, min: 0 },
+    totalViewerCount:  { type: Number, default: 0, min: 0 },
+    totalTipsReceived: { type: Number, default: 0, min: 0 },
+    streamKey:         { type: String, select: false },
+    playbackUrl:       { type: String },
+    thumbnailUrl:      { type: String },
+    tags:              { type: [String], default: [] },
+  },
+  { timestamps: true }
+);
+
+sessionSchema.index({ artistId: 1, state: 1 });
+sessionSchema.index({ state: 1, scheduledAt: 1 });
+
+export const Session = model<ISession>('Session', sessionSchema);

--- a/apps/api/src/lib/tip-schemas.ts
+++ b/apps/api/src/lib/tip-schemas.ts
@@ -1,0 +1,68 @@
+import { Schema, model, Document } from 'mongoose';
+
+export type TipIntentState = 'pending' | 'submitted' | 'confirmed' | 'failed' | 'expired';
+export type TipTxState = 'submitted' | 'confirmed' | 'failed';
+
+export interface ITipIntent extends Document {
+  fanId: string;
+  artistId: string;
+  sessionId: string;
+  amountLamports: number;
+  currency: string;
+  state: TipIntentState;
+  idempotencyKey: string;
+  txId?: string;
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface ITipTransaction extends Document {
+  intentId: string;
+  fanId: string;
+  artistId: string;
+  sessionId: string;
+  amountLamports: number;
+  txSignature: string;
+  state: TipTxState;
+  confirmedAt?: Date;
+  failureReason?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const tipIntentSchema = new Schema<ITipIntent>(
+  {
+    fanId:           { type: String, required: true, index: true },
+    artistId:        { type: String, required: true, index: true },
+    sessionId:       { type: String, required: true, index: true },
+    amountLamports:  { type: Number, required: true, min: 1 },
+    currency:        { type: String, required: true, default: 'SOL' },
+    state:           { type: String, enum: ['pending', 'submitted', 'confirmed', 'failed', 'expired'], default: 'pending' },
+    idempotencyKey:  { type: String, required: true, unique: true },
+    txId:            { type: String },
+    expiresAt:       { type: Date, required: true },
+  },
+  { timestamps: true }
+);
+
+const tipTransactionSchema = new Schema<ITipTransaction>(
+  {
+    intentId:       { type: String, required: true, unique: true, index: true },
+    fanId:          { type: String, required: true, index: true },
+    artistId:       { type: String, required: true, index: true },
+    sessionId:      { type: String, required: true, index: true },
+    amountLamports: { type: Number, required: true, min: 1 },
+    txSignature:    { type: String, required: true, unique: true },
+    state:          { type: String, enum: ['submitted', 'confirmed', 'failed'], default: 'submitted' },
+    confirmedAt:    { type: Date },
+    failureReason:  { type: String },
+  },
+  { timestamps: true }
+);
+
+tipIntentSchema.index({ sessionId: 1, state: 1 });
+tipTransactionSchema.index({ artistId: 1, state: 1 });
+
+export const TipIntent = model<ITipIntent>('TipIntent', tipIntentSchema);
+export const TipTransaction = model<ITipTransaction>('TipTransaction', tipTransactionSchema);


### PR DESCRIPTION
Adds canonical Mongoose schemas for the data model rebuild sprint.

- **CHORD-033** — ArtistProfile schema with genre, verification, payout, and discoverability fields; compound indexes for genre/verified and follower count queries.
- **CHORD-034** — Session schema covering draft, live, ended, and cancelled states with stream metadata, viewer counters, and archival timestamps.
- **CHORD-035** — TipIntent and TipTransaction schemas separating client intent from blockchain submission and settlement; idempotency key on intent, unique tx signature on transaction.
- **CHORD-036** — Moment, Vote, and Unlock schemas for forward-compatible interactive features; unique compound index prevents duplicate votes and duplicate unlocks per fan/session.

Closes #185, closes #186, closes #187, closes #188