### PR TITLE
feat: data model schemas for supporter reputation, audit events, and migrations

### DIFF
--- a/packages/types/src/audit-event.ts
+++ b/packages/types/src/audit-event.ts
@@ -1,0 +1,59 @@
+// CHORD-038: Admin audit and moderation event schemas
+// Immutable snapshots of actor, target, action, reason, and metadata.
+
+export type AuditAction =
+  | "user.ban"
+  | "user.unban"
+  | "user.warn"
+  | "content.remove"
+  | "content.restore"
+  | "tip.refund"
+  | "badge.revoke"
+  | "session.terminate";
+
+export type AuditSeverity = "info" | "warning" | "critical";
+
+export interface AuditActor {
+  userId: string;
+  role: "admin" | "moderator" | "system";
+  ip?: string;
+}
+
+export interface AuditTarget {
+  type: "user" | "content" | "tip" | "session";
+  id: string;
+  /** Human-readable snapshot at time of action */
+  snapshot?: Record<string, unknown>;
+}
+
+/** Primary document stored in `audit_events` collection. Append-only. */
+export interface AuditEvent {
+  _id: string;
+  action: AuditAction;
+  severity: AuditSeverity;
+  actor: AuditActor;
+  target: AuditTarget;
+  reason: string;
+  metadata?: Record<string, unknown>;
+  createdAt: Date; // immutable — never updated
+}
+
+// Indexes:
+//   { createdAt: -1 }                    — time-ordered log reads
+//   { "target.id": 1, createdAt: -1 }    — per-entity history
+//   { "actor.userId": 1, createdAt: -1 } — per-admin activity
+
+export function buildAuditEvent(
+  action: AuditAction,
+  actor: AuditActor,
+  target: AuditTarget,
+  reason: string,
+  metadata?: Record<string, unknown>
+): Omit<AuditEvent, "_id"> {
+  const severity: AuditSeverity =
+    action.endsWith(".ban") || action === "tip.refund" ? "critical"
+    : action.endsWith(".warn") ? "warning"
+    : "info";
+
+  return { action, severity, actor, target, reason, metadata, createdAt: new Date() };
+}

--- a/packages/types/src/migration.ts
+++ b/packages/types/src/migration.ts
@@ -1,0 +1,67 @@
+// CHORD-039: Migration framework for schema evolution
+// Idempotent, ordered migrations tracked in `_migrations` collection.
+
+export interface MigrationRecord {
+  _id: string;       // migration name, e.g. "001_add_reputation_indexes"
+  appliedAt: Date;
+  durationMs: number;
+}
+
+export interface Migration {
+  name: string;
+  up: (db: MigrationDb) => Promise<void>;
+  down?: (db: MigrationDb) => Promise<void>;
+}
+
+/** Minimal DB interface — swap in your Mongoose/native driver client. */
+export interface MigrationDb {
+  collection: (name: string) => {
+    createIndex: (spec: object, opts?: object) => Promise<void>;
+    dropIndex: (name: string) => Promise<void>;
+    insertOne: (doc: object) => Promise<void>;
+    findOne: (filter: object) => Promise<object | null>;
+  };
+}
+
+export async function runMigrations(
+  db: MigrationDb,
+  migrations: Migration[]
+): Promise<void> {
+  const col = db.collection("_migrations");
+
+  for (const migration of migrations) {
+    const already = await col.findOne({ _id: migration.name });
+    if (already) continue;
+
+    const start = Date.now();
+    await migration.up(db);
+    await col.insertOne({
+      _id: migration.name,
+      appliedAt: new Date(),
+      durationMs: Date.now() - start,
+    });
+
+    console.log(`[migration] applied: ${migration.name}`);
+  }
+}
+
+/** Canonical migrations for sprint-1 data model. */
+export const sprint1Migrations: Migration[] = [
+  {
+    name: "001_supporter_reputation_indexes",
+    async up(db) {
+      const col = db.collection("supporter_reputations");
+      await col.createIndex({ userId: 1, artistId: 1 }, { unique: true });
+      await col.createIndex({ artistId: 1, "level.level": -1 });
+    },
+  },
+  {
+    name: "002_audit_events_indexes",
+    async up(db) {
+      const col = db.collection("audit_events");
+      await col.createIndex({ createdAt: -1 });
+      await col.createIndex({ "target.id": 1, createdAt: -1 });
+      await col.createIndex({ "actor.userId": 1, createdAt: -1 });
+    },
+  },
+];

--- a/packages/types/src/seed.ts
+++ b/packages/types/src/seed.ts
@@ -1,0 +1,70 @@
+// CHORD-039: Seed data for local dev and test fixtures
+// Idempotent — safe to run multiple times.
+
+import type { SupporterReputation } from "./supporter-reputation";
+import type { AuditEvent } from "./audit-event";
+
+export const seedReputations: Omit<SupporterReputation, "updatedAt">[] = [
+  {
+    _id: "rep_001",
+    userId: "user_fan_alice",
+    artistId: "artist_001",
+    level: { level: 3, xp: 420, nextLevelXp: 521 },
+    streak: { currentDays: 7, longestDays: 14, lastActivityAt: new Date("2026-04-25") },
+    badges: [
+      { id: "badge_001", name: "First Drop", tier: "bronze", awardedAt: new Date("2026-01-10"), artistId: "artist_001" },
+    ],
+    totalTipped: 18.5,
+    createdAt: new Date("2026-01-10"),
+  },
+  {
+    _id: "rep_002",
+    userId: "user_fan_bob",
+    artistId: "artist_001",
+    level: { level: 7, xp: 1100, nextLevelXp: 1521 },
+    streak: { currentDays: 30, longestDays: 30, lastActivityAt: new Date("2026-04-26") },
+    badges: [
+      { id: "badge_002", name: "Loyal Chord", tier: "silver", awardedAt: new Date("2026-03-01"), artistId: "artist_001" },
+      { id: "badge_003", name: "Backstage Pass", tier: "gold", awardedAt: new Date("2026-04-01"), artistId: "artist_001" },
+    ],
+    totalTipped: 95.0,
+    createdAt: new Date("2026-01-15"),
+  },
+];
+
+export const seedAuditEvents: Omit<AuditEvent, "_id">[] = [
+  {
+    action: "user.warn",
+    severity: "warning",
+    actor: { userId: "admin_001", role: "admin", ip: "10.0.0.1" },
+    target: { type: "user", id: "user_bad_actor", snapshot: { username: "spammer99" } },
+    reason: "Repeated spam in live chat",
+    createdAt: new Date("2026-04-20"),
+  },
+  {
+    action: "content.remove",
+    severity: "info",
+    actor: { userId: "mod_001", role: "moderator" },
+    target: { type: "content", id: "post_xyz" },
+    reason: "Violates community guidelines",
+    createdAt: new Date("2026-04-22"),
+  },
+];
+
+export async function runSeed(db: {
+  collection: (name: string) => {
+    updateOne: (filter: object, update: object, opts: object) => Promise<void>;
+  };
+}): Promise<void> {
+  const reps = db.collection("supporter_reputations");
+  for (const rep of seedReputations) {
+    await reps.updateOne({ _id: rep._id }, { $setOnInsert: { ...rep, updatedAt: new Date() } }, { upsert: true });
+  }
+
+  const events = db.collection("audit_events");
+  for (const event of seedAuditEvents) {
+    await events.updateOne({ "target.id": event.target.id, action: event.action }, { $setOnInsert: event }, { upsert: true });
+  }
+
+  console.log("[seed] done — reputations and audit events seeded");
+}

--- a/packages/types/src/supporter-reputation.ts
+++ b/packages/types/src/supporter-reputation.ts
@@ -1,0 +1,61 @@
+// CHORD-037: Supporter reputation schema — badges, streaks, and levels
+// Canonical document structure for MongoDB-backed supporter reputation.
+
+export type BadgeTier = "bronze" | "silver" | "gold" | "platinum";
+
+export interface Badge {
+  id: string;
+  name: string;
+  tier: BadgeTier;
+  awardedAt: Date;
+  artistId: string; // scoped per-artist or "global"
+}
+
+export interface Streak {
+  currentDays: number;
+  longestDays: number;
+  lastActivityAt: Date;
+}
+
+export interface ReputationLevel {
+  level: number;       // 1–100
+  xp: number;          // cumulative XP
+  nextLevelXp: number; // XP required for next level
+}
+
+/** Primary document stored in `supporter_reputations` collection. */
+export interface SupporterReputation {
+  _id: string;           // MongoDB ObjectId as string
+  userId: string;
+  artistId: string;      // per-artist reputation record
+  level: ReputationLevel;
+  streak: Streak;
+  badges: Badge[];
+  totalTipped: number;   // lifetime USD-equivalent
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+// Indexes:
+//   { userId: 1, artistId: 1 }  unique — primary lookup
+//   { artistId: 1, "level.level": -1 }  — leaderboard queries
+
+export function calcNextLevelXp(level: number): number {
+  return Math.floor(100 * Math.pow(1.15, level));
+}
+
+export function awardXp(
+  rep: SupporterReputation,
+  xpGain: number
+): SupporterReputation {
+  const xp = rep.level.xp + xpGain;
+  let { level } = rep.level;
+  let nextLevelXp = rep.level.nextLevelXp;
+
+  while (xp >= nextLevelXp && level < 100) {
+    level += 1;
+    nextLevelXp = calcNextLevelXp(level);
+  }
+
+  return { ...rep, level: { level, xp, nextLevelXp }, updatedAt: new Date() };
+}


### PR DESCRIPTION
Adds canonical TypeScript schemas and utilities for the sprint-1 data model rebuild.

- `supporter-reputation.ts` — document structure, badge/streak/level types, and XP logic (CHORD-037)
- `audit-event.ts` — immutable admin/moderation event schema with actor, target, action, and severity (CHORD-038)
- `migration.ts` — idempotent migration runner and sprint-1 index migrations (CHORD-039)
- `seed.ts` — repeatable dev/test fixtures for reputations and audit events (CHORD-039)

Closes #189
Closes #190
Closes #191
Closes #192