### PR TITLE
feat: secrets management, observability baseline, incident runbook, and feature flag framework

### DIFF
--- a/docs/incident-runbook.md
+++ b/docs/incident-runbook.md
@@ -1,0 +1,76 @@
+# Incident Severity Matrix and Runbook Template
+
+This document provides on-call engineers with a clear severity classification and a repeatable runbook structure so incidents are handled consistently and post-mortems capture the right information.
+
+## Severity Matrix
+
+| Severity | Definition | Initial Response | Update Cadence | Escalation |
+|---|---|---|---|---|
+| **P0 — Critical** | Total service outage. All users unable to access the platform or a core service is completely unavailable. | 15 minutes | Every 15 minutes | CTO + all team leads immediately |
+| **P1 — High** | Major feature or payment flow is down. Significant subset of users impacted, no acceptable workaround. | 1 hour | Every 30 minutes | Engineering lead + product lead |
+| **P2 — Medium** | Degraded performance or non-critical feature unavailable. Workaround exists or impact is limited. | 4 hours | Every 2 hours | On-call engineer; escalate if not resolved in 4h |
+| **P3 — Low** | Minor issue with minimal user impact (cosmetic bug, slow non-critical endpoint). | Next business day | Daily during business hours | Standard ticket queue |
+
+---
+
+## Runbook Template
+
+Copy and fill in the sections below when an incident is declared.
+
+```
+# Incident: <Short Title>
+
+Date: YYYY-MM-DD
+Severity: P0 / P1 / P2 / P3
+Incident Commander: <name>
+Status: Investigating / Mitigating / Resolved
+```
+
+### 1. Detection
+
+- **How was the incident detected?** (Alert, user report, monitoring dashboard, etc.)
+- **Time of detection (UTC):**
+- **Alert or ticket link:**
+- **Initial symptoms observed:**
+
+### 2. Impact Assessment
+
+- **Services affected:**
+- **Estimated number of users impacted:**
+- **Geographic or segment scope:**
+- **Revenue or SLA impact:**
+- **Is data integrity at risk?** (Yes / No / Unknown)
+
+### 3. Mitigation
+
+- **Immediate actions taken** (with timestamps):
+  - `HH:MM UTC` — <action taken>
+  - `HH:MM UTC` — <action taken>
+- **Root cause hypothesis:**
+- **Mitigation applied:**
+- **Time to mitigation (TTM):**
+- **Validation:** How was it confirmed that the issue is resolved?
+
+### 4. Communication
+
+- **Internal notifications sent:** (Slack channel, who was paged)
+- **External / customer communication:** (Status page update, support email, etc.)
+- **Stakeholders notified:**
+- **Time of resolution communication (UTC):**
+
+### 5. Post-Mortem
+
+Complete within 48 hours of resolution for P0/P1, within one week for P2.
+
+- **Timeline of events** (detection → resolution, in chronological order):
+- **Root cause (confirmed):**
+- **Contributing factors:**
+- **What went well:**
+- **What went wrong:**
+- **Action items:**
+
+| Action | Owner | Due Date |
+|---|---|---|
+| <preventive/detective fix> | <name> | YYYY-MM-DD |
+
+- **Follow-up review scheduled:** YYYY-MM-DD

--- a/docs/observability-baseline.md
+++ b/docs/observability-baseline.md
@@ -1,0 +1,57 @@
+# Observability Stack Baseline
+
+This document specifies the logging, metrics, and tracing tools the Chordially team uses so that every engineer has a consistent, queryable view of system health from day one.
+
+## Three Pillars
+
+### 1. Logs
+
+**Tool:** [pino](https://github.com/pinojs/pino)
+
+- All services must emit structured JSON logs via `pino`. No unstructured `console.log` calls in production code.
+- Required fields on every log entry: `timestamp` (ISO 8601), `level`, `service`, `traceId`, `spanId`, `message`.
+- Log levels follow standard semantics: `fatal`, `error`, `warn`, `info`, `debug`, `trace`. Default production level: `info`.
+- Sensitive fields (tokens, passwords, email addresses) must be redacted before logging using `pino`'s `redact` option.
+- Logs are shipped to a centralised log aggregation service (e.g., Loki or CloudWatch Logs) and indexed for querying.
+
+**Naming convention for log sources:** `chordially.<service-name>` (e.g., `chordially.api`, `chordially.worker`).
+
+### 2. Metrics
+
+**Tools:** [Prometheus](https://prometheus.io/) + [Grafana](https://grafana.com/)
+
+- Each service exposes a `/metrics` endpoint in the Prometheus text format, scraped every 15 seconds.
+- Standard metrics to instrument in every service:
+  - `http_request_duration_seconds` — histogram of request latency, labelled by `method`, `route`, and `status_code`.
+  - `http_requests_total` — counter of total requests, same labels.
+  - `process_cpu_seconds_total` and `process_resident_memory_bytes` — via the default Node.js Prometheus client.
+- Custom business metrics must follow the naming pattern `chordially_<domain>_<metric>_<unit>` (e.g., `chordially_payments_tips_total`).
+
+**Alert threshold examples:**
+
+| Alert | Condition | Severity |
+|---|---|---|
+| High error rate | `rate(http_requests_total{status_code=~"5.."}[5m]) / rate(http_requests_total[5m]) > 0.05` | P1 |
+| Latency spike | `histogram_quantile(0.95, http_request_duration_seconds_bucket) > 2` | P2 |
+| Service down | `up == 0` for > 1 min | P0 |
+| Memory pressure | `process_resident_memory_bytes > 512MB` | P2 |
+
+**Dashboard naming convention:** `Chordially / <Domain> / <Service>` (e.g., `Chordially / Payments / API`). All dashboards live in the `chordially` Grafana folder and are version-controlled as JSON in `infra/grafana/dashboards/`.
+
+### 3. Traces
+
+**Tool:** [OpenTelemetry](https://opentelemetry.io/) (OTel)
+
+- All services initialise the OpenTelemetry Node.js SDK at startup using automatic instrumentation for HTTP, gRPC, and database clients.
+- Traces are exported to an OTel Collector, which forwards to the configured backend (Jaeger for local development, Tempo or AWS X-Ray for hosted environments).
+- Every inbound HTTP request must propagate a `traceId` and `spanId` via the W3C `traceparent` header.
+- The `traceId` must be included in log entries (see Logs section) to enable log-to-trace correlation in Grafana.
+- Sampling strategy: 100% in development and staging; 10% head-based sampling in production with 100% sampling for error spans.
+
+## Summary: Tool Choices
+
+| Pillar | Tool | Transport / Backend |
+|---|---|---|
+| Logs | pino | Loki (local), CloudWatch Logs (production) |
+| Metrics | Prometheus + Grafana | Prometheus scrape + Grafana dashboards |
+| Traces | OpenTelemetry SDK | Jaeger (local), Tempo / X-Ray (production) |

--- a/docs/secrets-management.md
+++ b/docs/secrets-management.md
@@ -1,0 +1,53 @@
+# Secrets Management
+
+This document establishes conventions for storing and accessing secrets across all environments in the Chordially platform.
+
+## Local Development
+
+- Use `.env` files at the project or package root to hold secrets and environment-specific configuration.
+- **Never commit `.env` files.** Ensure `.env` is listed in `.gitignore` at every level where it may appear.
+- Maintain a `.env.example` file alongside each `.env` file. The example file must list every required key with placeholder values and a brief comment explaining each one. It is safe to commit `.env.example`.
+- Developers clone the repo, copy `.env.example` to `.env`, and fill in real values obtained from a secure shared channel (e.g., 1Password team vault or a designated Slack DM with the team lead).
+- Never hard-code secrets in source files. If a secret is needed at build time, load it through `process.env` and document it in `.env.example`.
+
+## Continuous Integration (GitHub Actions)
+
+- All secrets used in CI pipelines must be stored as **GitHub Actions Secrets** at the repository or organization level.
+- Access secrets in workflow files with `${{ secrets.SECRET_NAME }}`. Do not echo or log secret values.
+- Use **environment-scoped variables** (Settings → Environments → Secrets) to separate staging and production values. Name environments consistently: `staging`, `production`.
+- Rotate CI secrets whenever a team member with access leaves the project or when a potential exposure is detected.
+- Avoid storing secrets in workflow YAML files or in environment variables that are printed in build logs.
+
+## Production
+
+- Production secrets must be stored in a dedicated secrets manager. Approved options:
+  - **HashiCorp Vault** — preferred for self-hosted or hybrid deployments.
+  - **AWS Secrets Manager** — preferred when the deployment target is AWS infrastructure.
+- Applications retrieve secrets at startup via the secrets manager SDK or a sidecar agent. Secrets are injected into the process environment and never written to disk.
+- Access to the secrets manager is controlled via IAM roles or Vault policies scoped to the minimum required permissions (principle of least privilege).
+- Secrets must not appear in application logs, error messages, or HTTP responses.
+
+## Secret Rotation Policy
+
+| Secret Type | Rotation Frequency |
+|---|---|
+| API keys (third-party services) | Every 90 days or on suspected exposure |
+| Database credentials | Every 180 days or on suspected exposure |
+| JWT signing keys | Every 365 days, rolling rotation with overlap period |
+| CI/CD secrets | Immediately when a team member with access departs |
+| Service-to-service tokens | Every 90 days |
+
+When rotating a secret:
+1. Generate the new value in the secrets manager first.
+2. Update all consumers (services, CI pipelines) to use the new value.
+3. Verify all consumers are operational with the new value.
+4. Revoke the old value.
+5. Document the rotation in the audit log.
+
+## Audit Logging for Secret Access
+
+- All read and write operations on secrets stored in Vault or AWS Secrets Manager must be captured in an audit log.
+- Audit logs must record: timestamp, principal (user or service identity), secret name (not value), action (read / create / update / delete), and source IP or service identifier.
+- Audit logs are retained for a minimum of 90 days and are stored in a location separate from application logs.
+- Access to audit logs is restricted to security-designated team members.
+- Review audit logs at least monthly and immediately following any security incident or suspected exposure.

--- a/packages/config/feature-flags-rollout.ts
+++ b/packages/config/feature-flags-rollout.ts
@@ -1,0 +1,29 @@
+/**
+ * Feature flag definitions for incremental rollout.
+ *
+ * Add new flags to the FLAGS object with a boolean value.
+ * Set a flag to `true` to enable the feature for all users,
+ * or `false` to keep it hidden behind the flag.
+ *
+ * Use `getFlag` to read a flag's current value at runtime.
+ */
+
+export const FLAGS = {
+  ENABLE_TIPPING: false,
+  ENABLE_LIVE_SESSION: false,
+  ENABLE_BLOCKCHAIN_TIPS: false,
+  ENABLE_AI_MODERATION: false,
+} as const satisfies Record<string, boolean>;
+
+/** Union type of all valid feature flag keys. */
+export type FeatureFlagKey = keyof typeof FLAGS;
+
+/**
+ * Returns the current value of the given feature flag.
+ *
+ * @param key - A key from the FLAGS object.
+ * @returns `true` if the feature is enabled, `false` otherwise.
+ */
+export function getFlag(key: FeatureFlagKey): boolean {
+  return FLAGS[key];
+}


### PR DESCRIPTION
## Summary

This PR addresses four related engineering-readiness issues covering how we handle secrets, observe system health, respond to incidents, and roll out features incrementally.

### CHORD-093 — Secrets Management (closes #245)

Adds `docs/secrets-management.md` establishing clear conventions for every environment:
- **Local dev:** `.env` files, never commit secrets, maintain `.env.example` as a template.
- **CI:** GitHub Actions Secrets scoped to named environments (`staging`, `production`).
- **Production:** HashiCorp Vault or AWS Secrets Manager; secrets injected at startup, never written to disk.
- Rotation schedule per secret type and audit logging requirements.

### CHORD-094 — Observability Baseline (closes #246)

Adds `docs/observability-baseline.md` specifying the three-pillar stack:
- **Logs:** structured JSON via `pino` with required fields, redaction rules, and source naming convention.
- **Metrics:** Prometheus scrape + Grafana dashboards; standard HTTP metrics, business metric naming pattern, and example alert thresholds (P0 `up == 0`, P1 high error rate, P2 latency spike).
- **Traces:** OpenTelemetry SDK with W3C `traceparent` propagation, OTel Collector export, and per-environment sampling strategy.

### CHORD-095 — Incident Severity Matrix and Runbook Template (closes #247)

Adds `docs/incident-runbook.md` giving on-call engineers:
- **Severity table:** P0 (15 min response, total outage), P1 (1 h, major feature down), P2 (4 h, degraded), P3 (next business day, minor).
- **Runbook template** with structured sections: Detection, Impact Assessment, Mitigation, Communication, Post-Mortem (with action-item table).

### CHORD-096 — Feature Flag Framework (closes #248)

Adds `packages/config/feature-flags-rollout.ts` providing:
- `FLAGS` — a typed `const` object with four boolean flags: `ENABLE_TIPPING`, `ENABLE_LIVE_SESSION`, `ENABLE_BLOCKCHAIN_TIPS`, `ENABLE_AI_MODERATION`.
- `FeatureFlagKey` — a type alias for `keyof typeof FLAGS`.
- `getFlag(key: FeatureFlagKey): boolean` — a simple accessor to read flag values at runtime.

## Files Changed

| File | Issue |
|---|---|
| `docs/secrets-management.md` | #245 |
| `docs/observability-baseline.md` | #246 |
| `docs/incident-runbook.md` | #247 |
| `packages/config/feature-flags-rollout.ts` | #248 |