### PR TITLE
feat: add mobile analytics, error boundary, EAS build profiles, and device matrix

### DIFF
--- a/apps/mobile/eas-profiles.json
+++ b/apps/mobile/eas-profiles.json
@@ -1,0 +1,20 @@
+{
+  "build": {
+    "development": {
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      },
+      "ios": {
+        "simulator": true
+      }
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {
+      "distribution": "store",
+      "autoIncrement": true
+    }
+  }
+}

--- a/apps/mobile/src/analytics/analytics.ts
+++ b/apps/mobile/src/analytics/analytics.ts
@@ -1,0 +1,20 @@
+export enum AnalyticsEvent {
+  SCREEN_VIEW = 'SCREEN_VIEW',
+  TAB_CHANGE = 'TAB_CHANGE',
+  BUTTON_PRESS = 'BUTTON_PRESS',
+  SESSION_START = 'SESSION_START',
+  ERROR = 'ERROR',
+}
+
+export function track(event: AnalyticsEvent, properties?: Record<string, unknown>): void {
+  if (__DEV__) {
+    console.log('[Analytics]', event, properties ?? {});
+  } else {
+    // TODO: forward to real analytics SDK (e.g. Segment, Amplitude)
+    // analyticsSDK.track(event, properties);
+  }
+}
+
+export function trackScreen(screenName: string): void {
+  track(AnalyticsEvent.SCREEN_VIEW, { screen: screenName });
+}

--- a/apps/mobile/src/components/ErrorBoundary.tsx
+++ b/apps/mobile/src/components/ErrorBoundary.tsx
@@ -1,0 +1,73 @@
+import React, { Component, ReactNode } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error?: Error;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    console.error('[ErrorBoundary] Caught error:', error, info);
+  }
+
+  handleRetry = (): void => {
+    this.setState({ hasError: false, error: undefined });
+  };
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <View style={styles.container}>
+          <Text style={styles.message}>Something went wrong</Text>
+          <TouchableOpacity style={styles.button} onPress={this.handleRetry}>
+            <Text style={styles.buttonText}>Try Again</Text>
+          </TouchableOpacity>
+        </View>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  message: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  button: {
+    backgroundColor: '#007AFF',
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 8,
+  },
+  buttonText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '500',
+  },
+});
+
+export default ErrorBoundary;

--- a/docs/device-matrix-plan.md
+++ b/docs/device-matrix-plan.md
@@ -1,0 +1,43 @@
+# Device Matrix Plan – Chordially MVP
+
+This document defines the device coverage required before each release milestone.
+
+## Priority Tiers
+
+| Tier | Description |
+|------|-------------|
+| P0   | Must pass on every sprint — blockers if failing |
+| P1   | Must pass before each release candidate |
+| P2   | Best-effort; failures are logged but non-blocking |
+
+## iOS Devices
+
+| Device        | OS Version | Priority | Notes                    |
+|---------------|------------|----------|--------------------------|
+| iPhone 15 Pro | iOS 17     | P0       | Latest flagship          |
+| iPhone 14     | iOS 17     | P0       | High market share        |
+| iPhone 13     | iOS 16     | P0       | Common deployment target |
+| iPhone 12     | iOS 16     | P1       | Lower end of support     |
+
+## Android Devices
+
+| Device            | OS Version  | Priority | Notes                         |
+|-------------------|-------------|----------|-------------------------------|
+| Pixel 6           | Android 12  | P0       | Reference Android hardware    |
+| Pixel 6           | Android 13  | P0       | OS upgrade coverage           |
+| Samsung Galaxy S22| Android 13  | P0       | High market share OEM         |
+| Samsung Galaxy S22| Android 14  | P1       | Latest Samsung OS             |
+| OnePlus 11        | Android 13  | P1       | Alternative OEM validation    |
+| OnePlus 11        | Android 14  | P2       | Extended coverage             |
+
+## Testing Cadence
+
+- **Each sprint (P0):** Run automated UI tests on P0 devices via emulator/simulator in CI.
+- **Pre-release (P0 + P1):** Manual smoke test on physical P0 and P1 devices before tagging a release candidate.
+- **Post-release (P2):** Community or QA team spot-checks on P2 devices within one week of release.
+
+## Notes
+
+- iOS Simulator covers basic layout and logic; at least one physical iPhone must be tested per release.
+- Android emulators (AVD) are acceptable for P0 CI runs; physical devices required for P1 pre-release sign-off.
+- New device additions require a PR updating this document and sign-off from the mobile lead.


### PR DESCRIPTION
## Summary

This PR implements four related mobile infrastructure improvements:

### CHORD-077 – Mobile Analytics Event Wrapper (#229)
Adds `apps/mobile/src/analytics/analytics.ts` with a typed `AnalyticsEvent` enum (`SCREEN_VIEW`, `TAB_CHANGE`, `BUTTON_PRESS`, `SESSION_START`, `ERROR`), a centralised `track(event, properties?)` function (console output in dev, SDK hook in prod), and a `trackScreen(screenName)` convenience helper. Eliminates scattered third-party SDK calls across the codebase.

### CHORD-078 – App-Level Error Boundary and Crash Recovery UX (#230)
Adds `apps/mobile/src/components/ErrorBoundary.tsx`, a React class component that catches unhandled errors at the root level via `getDerivedStateFromError` and `componentDidCatch`, and renders a fallback screen with a "Try Again" `TouchableOpacity` that resets component state.

### CHORD-079 – EAS Build Profile Matrix (#231)
Adds `apps/mobile/eas-profiles.json` defining three EAS build profiles: `development` (internal distribution, APK for Android, simulator for iOS), `preview` (internal distribution), and `production` (store distribution with auto-increment).

### CHORD-080 – Device Matrix Plan for iOS and Android MVP (#232)
Adds `docs/device-matrix-plan.md` documenting P0/P1/P2 priority tiers, specific iPhone (12–15, iOS 16–17) and Android (Pixel 6, Samsung S22, OnePlus 11, Android 12–14) device targets, and per-sprint testing cadence.

## Test plan

- [ ] Verify `analytics.ts` exports compile cleanly under the project's TypeScript config
- [ ] Render `ErrorBoundary` in a test harness; confirm fallback UI appears on thrown error and `Try Again` restores children
- [ ] Validate `eas-profiles.json` is accepted by `eas build --profile development/preview/production`
- [ ] Review device matrix table for completeness before next release candidate

Closes #229, closes #230, closes #231, closes #232