### PR TITLE
Artist profile layer: wallet, moderation, fan privacy, contract tests

### DIFF
--- a/apps/api/src/modules/artist-profile/fan-privacy.ts
+++ b/apps/api/src/modules/artist-profile/fan-privacy.ts
@@ -1,0 +1,62 @@
+// CHORD-059: Fan privacy controls for leaderboard display names
+
+export type DisplayNameMode = "real" | "pseudonym" | "anonymous";
+
+export interface FanPrivacySettings {
+  fanId: string;
+  globalMode: DisplayNameMode;
+  pseudonym: string | null;
+  sessionOverrides: Record<string, DisplayNameMode>;
+  updatedAt: string;
+}
+
+const store = new Map<string, FanPrivacySettings>();
+
+export function initFanPrivacy(fanId: string): FanPrivacySettings {
+  const settings: FanPrivacySettings = {
+    fanId,
+    globalMode: "real",
+    pseudonym: null,
+    sessionOverrides: {},
+    updatedAt: new Date().toISOString(),
+  };
+  store.set(fanId, settings);
+  return settings;
+}
+
+export function setGlobalDisplayMode(
+  fanId: string,
+  mode: DisplayNameMode,
+  pseudonym?: string
+): FanPrivacySettings {
+  const existing = store.get(fanId) ?? initFanPrivacy(fanId);
+  if (mode === "pseudonym" && !pseudonym) throw new Error("pseudonym required when mode is pseudonym");
+  const updated: FanPrivacySettings = {
+    ...existing,
+    globalMode: mode,
+    pseudonym: pseudonym ?? existing.pseudonym,
+    updatedAt: new Date().toISOString(),
+  };
+  store.set(fanId, updated);
+  return updated;
+}
+
+export function setSessionOverride(fanId: string, sessionId: string, mode: DisplayNameMode): void {
+  const settings = store.get(fanId) ?? initFanPrivacy(fanId);
+  settings.sessionOverrides[sessionId] = mode;
+  settings.updatedAt = new Date().toISOString();
+  store.set(fanId, settings);
+}
+
+export function resolveDisplayName(fanId: string, realName: string, sessionId?: string): string {
+  const settings = store.get(fanId);
+  if (!settings) return realName;
+  const mode = sessionId ? (settings.sessionOverrides[sessionId] ?? settings.globalMode) : settings.globalMode;
+  if (mode === "anonymous") return "Anonymous";
+  if (mode === "pseudonym") return settings.pseudonym ?? realName;
+  return realName;
+}
+
+export function getFanPrivacy(fanId: string): FanPrivacySettings | null {
+  return store.get(fanId) ?? null;
+}

--- a/apps/api/src/modules/artist-profile/moderation.ts
+++ b/apps/api/src/modules/artist-profile/moderation.ts
@@ -1,0 +1,63 @@
+// CHORD-058: Profile moderation fields and controls
+
+export type ModerationState = "active" | "hidden" | "shadow_restricted" | "under_review";
+
+export interface ModerationRecord {
+  profileId: string;
+  state: ModerationState;
+  reason: string | null;
+  reviewedBy: string | null;
+  updatedAt: string;
+}
+
+const store = new Map<string, ModerationRecord>();
+
+export function initModeration(profileId: string): ModerationRecord {
+  const record: ModerationRecord = {
+    profileId,
+    state: "active",
+    reason: null,
+    reviewedBy: null,
+    updatedAt: new Date().toISOString(),
+  };
+  store.set(profileId, record);
+  return record;
+}
+
+export function setModerationState(
+  profileId: string,
+  state: ModerationState,
+  reviewedBy: string,
+  reason?: string
+): ModerationRecord {
+  const existing = store.get(profileId) ?? initModeration(profileId);
+  const updated: ModerationRecord = {
+    ...existing,
+    state,
+    reason: reason ?? null,
+    reviewedBy,
+    updatedAt: new Date().toISOString(),
+  };
+  store.set(profileId, updated);
+  auditModeration(profileId, state, reviewedBy);
+  return updated;
+}
+
+export function getModerationRecord(profileId: string): ModerationRecord | null {
+  return store.get(profileId) ?? null;
+}
+
+export function isProfileVisible(profileId: string): boolean {
+  const record = store.get(profileId);
+  return !record || record.state === "active";
+}
+
+const auditLog: Array<{ profileId: string; state: string; by: string; ts: string }> = [];
+
+function auditModeration(profileId: string, state: string, by: string): void {
+  auditLog.push({ profileId, state, by, ts: new Date().toISOString() });
+}
+
+export function getModerationAuditLog(profileId: string) {
+  return auditLog.filter((e) => e.profileId === profileId);
+}

--- a/apps/api/src/modules/artist-profile/profile.contract.test.ts
+++ b/apps/api/src/modules/artist-profile/profile.contract.test.ts
@@ -1,0 +1,79 @@
+// CHORD-060: Contract tests for profile APIs and slug behavior
+
+import { resolveSlug } from "./slug.js";
+import { isProfileVisible, setModerationState, initModeration } from "./moderation.js";
+import { resolveDisplayName, setGlobalDisplayMode } from "./fan-privacy.js";
+import { attachWallet, verifyWallet, getWallet } from "./wallet.js";
+
+type TestResult = { name: string; passed: boolean; error?: string };
+const results: TestResult[] = [];
+
+function test(name: string, fn: () => void) {
+  try {
+    fn();
+    results.push({ name, passed: true });
+  } catch (e) {
+    results.push({ name, passed: false, error: String(e) });
+  }
+}
+
+function assert(condition: boolean, msg: string) {
+  if (!condition) throw new Error(`Assertion failed: ${msg}`);
+}
+
+// Slug contract tests
+test("slug resolves lowercase hyphenated form", () => {
+  const slug = resolveSlug("My Artist Name");
+  assert(slug === slug.toLowerCase(), "slug must be lowercase");
+  assert(!slug.includes(" "), "slug must not contain spaces");
+});
+
+test("slug rejects empty string", () => {
+  let threw = false;
+  try { resolveSlug(""); } catch { threw = true; }
+  assert(threw, "empty slug should throw");
+});
+
+// Moderation visibility contract
+test("new profile is visible by default", () => {
+  initModeration("artist-vis-1");
+  assert(isProfileVisible("artist-vis-1"), "active profile should be visible");
+});
+
+test("hidden profile is not visible", () => {
+  setModerationState("artist-vis-2", "hidden", "admin-1");
+  assert(!isProfileVisible("artist-vis-2"), "hidden profile should not be visible");
+});
+
+// Fan privacy display name contract
+test("anonymous mode returns Anonymous", () => {
+  setGlobalDisplayMode("fan-1", "anonymous");
+  assert(resolveDisplayName("fan-1", "Alice") === "Anonymous", "anonymous mode must return Anonymous");
+});
+
+test("pseudonym mode returns pseudonym", () => {
+  setGlobalDisplayMode("fan-2", "pseudonym", "StarGazer");
+  assert(resolveDisplayName("fan-2", "Bob") === "StarGazer", "pseudonym mode must return pseudonym");
+});
+
+// Wallet attachment contract
+test("wallet attaches and verifies", () => {
+  attachWallet({ artistId: "artist-w1", address: "0xabc", network: "ethereum", verified: false, lastValidatedAt: null });
+  const verified = verifyWallet("artist-w1");
+  assert(verified.verified === true, "wallet should be verified after verifyWallet");
+  assert(getWallet("artist-w1")?.address === "0xabc", "wallet address should persist");
+});
+
+test("wallet attach requires address", () => {
+  let threw = false;
+  try { attachWallet({ artistId: "artist-w2", address: "", network: "solana", verified: false, lastValidatedAt: null }); }
+  catch { threw = true; }
+  assert(threw, "empty address should throw");
+});
+
+export function runContractTests(): TestResult[] {
+  const passed = results.filter((r) => r.passed).length;
+  console.log(`Contract tests: ${passed}/${results.length} passed`);
+  results.filter((r) => !r.passed).forEach((r) => console.error(`  FAIL: ${r.name} — ${r.error}`));
+  return results;
+}

--- a/apps/api/src/modules/artist-profile/wallet.ts
+++ b/apps/api/src/modules/artist-profile/wallet.ts
@@ -1,0 +1,53 @@
+// CHORD-057: Wallet attachment metadata on artist profiles
+
+export type WalletNetwork = "ethereum" | "solana" | "polygon";
+
+export interface WalletAttachment {
+  artistId: string;
+  address: string;
+  network: WalletNetwork;
+  verified: boolean;
+  lastValidatedAt: string | null;
+}
+
+const store = new Map<string, WalletAttachment>();
+
+export function attachWallet(data: WalletAttachment): WalletAttachment {
+  if (!data.address || !data.artistId) {
+    throw new Error("artistId and address are required");
+  }
+  const record: WalletAttachment = { ...data, lastValidatedAt: new Date().toISOString() };
+  store.set(data.artistId, record);
+  auditWalletChange(data.artistId, "attached", data.address);
+  return record;
+}
+
+export function verifyWallet(artistId: string): WalletAttachment {
+  const wallet = store.get(artistId);
+  if (!wallet) throw new Error(`No wallet found for artist ${artistId}`);
+  const updated = { ...wallet, verified: true, lastValidatedAt: new Date().toISOString() };
+  store.set(artistId, updated);
+  auditWalletChange(artistId, "verified", wallet.address);
+  return updated;
+}
+
+export function getWallet(artistId: string): WalletAttachment | null {
+  return store.get(artistId) ?? null;
+}
+
+export function detachWallet(artistId: string): void {
+  if (!store.has(artistId)) throw new Error(`No wallet found for artist ${artistId}`);
+  const wallet = store.get(artistId)!;
+  store.delete(artistId);
+  auditWalletChange(artistId, "detached", wallet.address);
+}
+
+const auditLog: Array<{ artistId: string; action: string; address: string; ts: string }> = [];
+
+function auditWalletChange(artistId: string, action: string, address: string): void {
+  auditLog.push({ artistId, action, address, ts: new Date().toISOString() });
+}
+
+export function getWalletAuditLog(artistId: string) {
+  return auditLog.filter((e) => e.artistId === artistId);
+}


### PR DESCRIPTION
Closes #209, closes #210, closes #211, closes #212

- **CHORD-057**: `wallet.ts` — attach/verify/detach payout wallet with audit log
- **CHORD-058**: `moderation.ts` — hidden/shadow/review states with visibility guard and audit trail
- **CHORD-059**: `fan-privacy.ts` — global and per-session display name modes (real/pseudonym/anonymous)
- **CHORD-060**: `profile.contract.test.ts` — contract tests covering slug, moderation visibility, fan privacy, and wallet flows