### PR TITLE
feat: web foundation – route groups, tokens, form hook, cookie auth

### DIFF
--- a/apps/web/app/auth.ts
+++ b/apps/web/app/auth.ts
@@ -1,0 +1,53 @@
+/**
+ * CHORD-064 – Cookie-based auth integration for server and client components.
+ *
+ * Server-side helpers read the session cookie via next/headers; the client
+ * helper clears it through a fetch to the sign-out route.
+ */
+
+import { cookies } from "next/headers";
+
+const SESSION_COOKIE = "chordially_session";
+
+export interface Session {
+  userId: string;
+  role: "artist" | "fan" | "admin";
+  expiresAt: number;
+}
+
+/** Server-only: parse and return the current session, or null if absent/expired. */
+export async function getSession(): Promise<Session | null> {
+  const cookieStore = await cookies();
+  const raw = cookieStore.get(SESSION_COOKIE)?.value;
+  if (!raw) return null;
+
+  let session: Session;
+  try {
+    session = JSON.parse(Buffer.from(raw, "base64").toString("utf8")) as Session;
+  } catch {
+    return null;
+  }
+
+  if (Date.now() > session.expiresAt) return null;
+  return session;
+}
+
+/** Server-only: assert a session exists, throw if not (use in Server Actions). */
+export async function requireSession(): Promise<Session> {
+  const session = await getSession();
+  if (!session) throw new Error("Unauthenticated");
+  return session;
+}
+
+/** Server-only: assert the session role matches one of the allowed roles. */
+export async function requireRole(...roles: Session["role"][]): Promise<Session> {
+  const session = await requireSession();
+  if (!roles.includes(session.role)) throw new Error("Forbidden");
+  return session;
+}
+
+/** Client-side: call the sign-out API route and reload. */
+export async function signOut(): Promise<void> {
+  await fetch("/api/auth/sign-out", { method: "POST" });
+  window.location.href = "/login";
+}

--- a/apps/web/app/route-groups.ts
+++ b/apps/web/app/route-groups.ts
@@ -1,0 +1,57 @@
+/**
+ * CHORD-061 – Route group definitions for the Next.js app shell.
+ *
+ * Separates public, authenticated-artist, authenticated-fan, and admin
+ * experiences so each segment can carry its own layout and middleware.
+ */
+
+export type RouteGroup = "public" | "artist" | "fan" | "admin";
+
+interface RouteConfig {
+  group: RouteGroup;
+  /** Path prefix used in the (group) folder convention */
+  prefix: string;
+  /** Whether the segment requires an authenticated session */
+  protected: boolean;
+  /** Roles allowed to access this segment */
+  roles: string[];
+}
+
+export const ROUTE_GROUPS: RouteConfig[] = [
+  {
+    group: "public",
+    prefix: "(public)",
+    protected: false,
+    roles: [],
+  },
+  {
+    group: "artist",
+    prefix: "(artist)",
+    protected: true,
+    roles: ["artist"],
+  },
+  {
+    group: "fan",
+    prefix: "(fan)",
+    protected: true,
+    roles: ["fan"],
+  },
+  {
+    group: "admin",
+    prefix: "(admin)",
+    protected: true,
+    roles: ["admin"],
+  },
+];
+
+/** Returns the config for a given route group, throwing if unknown. */
+export function getRouteGroup(group: RouteGroup): RouteConfig {
+  const config = ROUTE_GROUPS.find((r) => r.group === group);
+  if (!config) throw new Error(`Unknown route group: ${group}`);
+  return config;
+}
+
+/** Returns true when the path prefix belongs to a protected segment. */
+export function isProtectedPrefix(prefix: string): boolean {
+  return ROUTE_GROUPS.some((r) => r.protected && prefix.startsWith(r.prefix));
+}

--- a/apps/web/components/ui/tokens.ts
+++ b/apps/web/components/ui/tokens.ts
@@ -1,0 +1,60 @@
+/**
+ * CHORD-062 – Design token system for Chordially brand primitives.
+ *
+ * Defines spacing, typography, color, elevation, motion, and responsive
+ * breakpoints as typed constants consumed by components and CSS-in-JS.
+ */
+
+export const color = {
+  brand: {
+    primary: "#7C3AED",
+    secondary: "#A78BFA",
+    accent: "#F59E0B",
+  },
+  neutral: {
+    0: "#FFFFFF",
+    100: "#F5F5F5",
+    200: "#E5E5E5",
+    700: "#404040",
+    900: "#171717",
+  },
+  feedback: {
+    error: "#EF4444",
+    success: "#22C55E",
+    warning: "#F59E0B",
+  },
+} as const;
+
+export const spacing = {
+  1: "0.25rem",
+  2: "0.5rem",
+  4: "1rem",
+  6: "1.5rem",
+  8: "2rem",
+  12: "3rem",
+  16: "4rem",
+} as const;
+
+export const typography = {
+  fontFamily: { sans: "Inter, system-ui, sans-serif", mono: "JetBrains Mono, monospace" },
+  fontSize: { xs: "0.75rem", sm: "0.875rem", base: "1rem", lg: "1.125rem", xl: "1.25rem", "2xl": "1.5rem", "4xl": "2.25rem" },
+  fontWeight: { normal: 400, medium: 500, semibold: 600, bold: 700 },
+} as const;
+
+export const elevation = {
+  sm: "0 1px 2px rgba(0,0,0,.06)",
+  md: "0 4px 6px rgba(0,0,0,.08)",
+  lg: "0 10px 15px rgba(0,0,0,.10)",
+} as const;
+
+export const motion = {
+  duration: { fast: "100ms", base: "200ms", slow: "400ms" },
+  easing: { standard: "cubic-bezier(0.4,0,0.2,1)", decelerate: "cubic-bezier(0,0,0.2,1)" },
+} as const;
+
+export const breakpoint = {
+  sm: "640px",
+  md: "768px",
+  lg: "1024px",
+  xl: "1280px",
+} as const;

--- a/apps/web/components/ui/use-form.ts
+++ b/apps/web/components/ui/use-form.ts
@@ -1,0 +1,62 @@
+"use client";
+
+/**
+ * CHORD-063 – Reusable form system with validation state and async submission.
+ *
+ * Provides a hook that standardises field errors, loading state, and
+ * optimistic submission feedback across all web forms.
+ */
+
+import { useState, useCallback, FormEvent } from "react";
+
+export type FieldErrors<T> = Partial<Record<keyof T, string>>;
+
+export interface FormState<T> {
+  values: T;
+  errors: FieldErrors<T>;
+  isSubmitting: boolean;
+  submitError: string | null;
+  submitSuccess: boolean;
+}
+
+export interface UseFormOptions<T> {
+  initialValues: T;
+  validate?: (values: T) => FieldErrors<T>;
+  onSubmit: (values: T) => Promise<void>;
+}
+
+export function useForm<T extends Record<string, unknown>>({
+  initialValues,
+  validate,
+  onSubmit,
+}: UseFormOptions<T>) {
+  const [state, setState] = useState<FormState<T>>({
+    values: initialValues,
+    errors: {},
+    isSubmitting: false,
+    submitError: null,
+    submitSuccess: false,
+  });
+
+  const setField = useCallback(<K extends keyof T>(key: K, value: T[K]) => {
+    setState((s) => ({ ...s, values: { ...s.values, [key]: value }, errors: { ...s.errors, [key]: undefined } }));
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (e: FormEvent) => {
+      e.preventDefault();
+      const errors = validate ? validate(state.values) : {};
+      if (Object.keys(errors).length) { setState((s) => ({ ...s, errors })); return; }
+      setState((s) => ({ ...s, isSubmitting: true, submitError: null, submitSuccess: false }));
+      try {
+        await onSubmit(state.values);
+        setState((s) => ({ ...s, isSubmitting: false, submitSuccess: true }));
+      } catch (err) {
+        setState((s) => ({ ...s, isSubmitting: false, submitError: (err as Error).message ?? "Submission failed" }));
+      }
+    },
+    [state.values, validate, onSubmit],
+  );
+
+  return { ...state, setField, handleSubmit };
+}


### PR DESCRIPTION
Closes #213, closes #214, closes #215, closes #216

**CHORD-061** – Adds `route-groups.ts` defining the four Next.js route group segments (public, artist, fan, admin) with role guards and prefix helpers.

**CHORD-062** – Adds `tokens.ts` with typed design token constants for color, spacing, typography, elevation, motion, and breakpoints.

**CHORD-063** – Adds `use-form.ts`, a generic React hook that manages field values, per-field validation errors, async submission state, and success/error feedback.

**CHORD-064** – Adds `auth.ts` with server-side session helpers (`getSession`, `requireSession`, `requireRole`) that read the cookie via `next/headers`, plus a client-side `signOut` helper.