### PR TITLE
feat(web): web foundation — route guards, page states, analytics & nav

### DIFF
--- a/apps/web/components/AppNav.tsx
+++ b/apps/web/components/AppNav.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+interface NavItem {
+  href: string;
+  label: string;
+  icon: string;
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { href: "/", label: "Discover", icon: "🎵" },
+  { href: "/live", label: "Live", icon: "🔴" },
+  { href: "/wallet", label: "Wallet", icon: "💸" },
+  { href: "/profile", label: "Profile", icon: "🎤" },
+];
+
+function NavLink({ item, active }: { item: NavItem; active: boolean }) {
+  return (
+    <Link
+      href={item.href}
+      className={`flex flex-col items-center gap-0.5 text-xs font-medium transition-colors
+        ${active ? "text-violet-400" : "text-zinc-400 hover:text-zinc-100"}`}
+    >
+      <span className="text-xl leading-none">{item.icon}</span>
+      {item.label}
+    </Link>
+  );
+}
+
+// Mobile: fixed bottom bar
+export function BottomNav() {
+  const pathname = usePathname();
+  return (
+    <nav className="fixed bottom-0 inset-x-0 z-50 flex justify-around border-t border-zinc-800 bg-zinc-950 px-2 py-3 md:hidden">
+      {NAV_ITEMS.map((item) => (
+        <NavLink key={item.href} item={item} active={pathname === item.href} />
+      ))}
+    </nav>
+  );
+}
+
+// Desktop: left sidebar
+export function SideNav() {
+  const pathname = usePathname();
+  return (
+    <aside className="hidden md:flex flex-col gap-1 w-52 shrink-0 border-r border-zinc-800 bg-zinc-950 px-4 py-8 min-h-screen">
+      <span className="mb-6 text-lg font-bold text-violet-400">Chordially</span>
+      {NAV_ITEMS.map((item) => (
+        <Link
+          key={item.href}
+          href={item.href}
+          className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors
+            ${pathname === item.href ? "bg-violet-900/40 text-violet-300" : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"}`}
+        >
+          <span>{item.icon}</span>
+          {item.label}
+        </Link>
+      ))}
+    </aside>
+  );
+}

--- a/apps/web/components/PageStates.tsx
+++ b/apps/web/components/PageStates.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { ReactNode } from "react";
+
+interface Props {
+  icon: string;
+  heading: string;
+  sub?: string;
+  action?: ReactNode;
+}
+
+function StateShell({ icon, heading, sub, action }: Props) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 py-24 text-center">
+      <span className="text-5xl">{icon}</span>
+      <h2 className="text-lg font-semibold text-zinc-100">{heading}</h2>
+      {sub && <p className="max-w-xs text-sm text-zinc-400">{sub}</p>}
+      {action}
+    </div>
+  );
+}
+
+export function EmptyState({ label = "Nothing here yet" }: { label?: string }) {
+  return <StateShell icon="🎵" heading={label} sub="Check back soon or explore other artists." />;
+}
+
+export function LoadingState() {
+  return (
+    <div className="flex h-64 items-center justify-center">
+      <div className="h-8 w-8 animate-spin rounded-full border-2 border-violet-500 border-t-transparent" />
+    </div>
+  );
+}
+
+export function OfflineState() {
+  return (
+    <StateShell
+      icon="📡"
+      heading="You're offline"
+      sub="Reconnect to keep the music going."
+      action={
+        <button
+          onClick={() => window.location.reload()}
+          className="mt-2 rounded-full bg-violet-600 px-5 py-2 text-sm font-medium text-white hover:bg-violet-500"
+        >
+          Retry
+        </button>
+      }
+    />
+  );
+}
+
+export function ErrorState({ message = "Something went wrong." }: { message?: string }) {
+  return (
+    <StateShell
+      icon="⚠️"
+      heading="Oops"
+      sub={message}
+      action={
+        <button
+          onClick={() => window.location.reload()}
+          className="mt-2 rounded-full bg-red-600 px-5 py-2 text-sm font-medium text-white hover:bg-red-500"
+        >
+          Try again
+        </button>
+      }
+    />
+  );
+}

--- a/apps/web/components/ProtectedRoute.tsx
+++ b/apps/web/components/ProtectedRoute.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter, usePathname } from "next/navigation";
+
+type Role = "artist" | "admin" | "fan";
+
+interface ProtectedRouteProps {
+  children: React.ReactNode;
+  requiredRole: Role;
+}
+
+// Minimal auth store — swap with real session/JWT logic
+function useAuth(): { role: Role | null; loading: boolean } {
+  const [role, setRole] = useState<Role | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("chordially:role") as Role | null;
+    setRole(stored);
+    setLoading(false);
+  }, []);
+
+  return { role, loading };
+}
+
+const ROLE_HOME: Record<Role, string> = {
+  artist: "/artist/dashboard",
+  admin: "/admin/dashboard",
+  fan: "/",
+};
+
+export default function ProtectedRoute({ children, requiredRole }: ProtectedRouteProps) {
+  const { role, loading } = useAuth();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (loading) return;
+
+    if (!role) {
+      router.replace(`/login?return=${encodeURIComponent(pathname)}`);
+      return;
+    }
+
+    if (role !== requiredRole) {
+      router.replace(ROLE_HOME[role]);
+    }
+  }, [role, loading, requiredRole, router, pathname]);
+
+  if (loading || !role || role !== requiredRole) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <span className="animate-pulse text-sm text-zinc-400">Checking access…</span>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/apps/web/components/useAnalytics.ts
+++ b/apps/web/components/useAnalytics.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useCallback } from "react";
+
+type EventMap = {
+  discovery_impression: { artistId: string; source: string };
+  session_join: { sessionId: string; artistId: string };
+  tip_attempt: { sessionId: string; amountUsd: number; currency: "USDC" | "XLM" };
+  tip_success: { sessionId: string; txHash: string };
+  onboarding_step: { step: string; role: "artist" | "fan" };
+};
+
+type EventName = keyof EventMap;
+
+function dispatch<E extends EventName>(name: E, payload: EventMap[E]) {
+  if (typeof window === "undefined") return;
+
+  // Swap the console.log for your real analytics sink (Segment, PostHog, etc.)
+  console.log("[analytics]", name, payload);
+
+  // Example: window.analytics?.track(name, payload);
+}
+
+export function useAnalytics() {
+  const track = useCallback(<E extends EventName>(name: E, payload: EventMap[E]) => {
+    dispatch(name, payload);
+  }, []);
+
+  return { track };
+}
+
+// Convenience typed helpers
+export const analytics = {
+  discoveryImpression: (p: EventMap["discovery_impression"]) =>
+    dispatch("discovery_impression", p),
+  sessionJoin: (p: EventMap["session_join"]) => dispatch("session_join", p),
+  tipAttempt: (p: EventMap["tip_attempt"]) => dispatch("tip_attempt", p),
+  tipSuccess: (p: EventMap["tip_success"]) => dispatch("tip_success", p),
+  onboardingStep: (p: EventMap["onboarding_step"]) => dispatch("onboarding_step", p),
+};


### PR DESCRIPTION
Closes #217, #218, #219, #220

**CHORD-065** — `ProtectedRoute` component redirects unauthenticated users to `/login?return=<path>` and role-mismatches to their home route.

**CHORD-066** — `PageStates` exports `EmptyState`, `LoadingState`, `OfflineState`, and `ErrorState` to eliminate blank screens across degraded conditions.

**CHORD-067** — `useAnalytics` hook + `analytics` helpers emit typed events (discovery impression, session join, tip attempt/success, onboarding step) — swap the `console.log` for your real sink.

**CHORD-068** — `BottomNav` (mobile fixed bar) and `SideNav` (desktop sidebar) share the same nav items and active-state logic, responsive via Tailwind breakpoints.