### PR TITLE
feat: auth contracts, password policy, user repo, and hasher

### DIFF
--- a/apps/api/src/password-hasher.ts
+++ b/apps/api/src/password-hasher.ts
@@ -1,0 +1,44 @@
+import { randomBytes, scrypt, timingSafeEqual } from "node:crypto";
+import { promisify } from "node:util";
+
+const scryptAsync = promisify(scrypt);
+
+const SALT_BYTES = 16;
+const KEY_LEN = 64;
+const SEPARATOR = ":";
+
+// ── Interface ─────────────────────────────────────────────────────────────────
+
+export interface PasswordHasher {
+  hash(plaintext: string): Promise<string>;
+  verify(plaintext: string, stored: string): Promise<boolean>;
+}
+
+// ── scrypt adapter ────────────────────────────────────────────────────────────
+
+/**
+ * Hashes passwords with Node's built-in scrypt so no extra dependencies are
+ * needed. Stored format: `<hex-salt>:<hex-hash>`.
+ */
+export class ScryptHasher implements PasswordHasher {
+  async hash(plaintext: string): Promise<string> {
+    const salt = randomBytes(SALT_BYTES).toString("hex");
+    const derived = (await scryptAsync(plaintext, salt, KEY_LEN)) as Buffer;
+    return `${salt}${SEPARATOR}${derived.toString("hex")}`;
+  }
+
+  async verify(plaintext: string, stored: string): Promise<boolean> {
+    const [salt, hash] = stored.split(SEPARATOR);
+    if (!salt || !hash) return false;
+
+    const derived = (await scryptAsync(plaintext, salt, KEY_LEN)) as Buffer;
+    const storedBuf = Buffer.from(hash, "hex");
+
+    if (derived.length !== storedBuf.length) return false;
+    return timingSafeEqual(derived, storedBuf);
+  }
+}
+
+// ── Singleton for the API process ─────────────────────────────────────────────
+
+export const passwordHasher: PasswordHasher = new ScryptHasher();

--- a/apps/api/src/password-policy.ts
+++ b/apps/api/src/password-policy.ts
@@ -1,0 +1,41 @@
+import type { AuthErrorCode } from "@chordially/types/auth-contracts";
+
+export type PolicyResult =
+  | { ok: true }
+  | { ok: false; code: AuthErrorCode; reason: string };
+
+const RULES: Array<{ test: (p: string) => boolean; reason: string }> = [
+  { test: (p) => p.length >= 8,          reason: "Password must be at least 8 characters." },
+  { test: (p) => p.length <= 128,        reason: "Password must not exceed 128 characters." },
+  { test: (p) => !/^\s|\s$/.test(p),     reason: "Password must not start or end with whitespace." },
+  { test: (p) => /[A-Z]/.test(p),        reason: "Password must contain at least one uppercase letter." },
+  { test: (p) => /[0-9]/.test(p),        reason: "Password must contain at least one digit." },
+  { test: (p) => /[^A-Za-z0-9]/.test(p), reason: "Password must contain at least one special character." },
+];
+
+/**
+ * Validates a plaintext password against the Chordially password policy.
+ * Returns the first failing rule so clients can surface actionable feedback.
+ */
+export function validatePassword(password: string): PolicyResult {
+  for (const rule of RULES) {
+    if (!rule.test(password)) {
+      return { ok: false, code: "POLICY_VIOLATION", reason: rule.reason };
+    }
+  }
+  return { ok: true };
+}
+
+/**
+ * Throws a structured error if the password violates policy.
+ * Convenience wrapper for use inside route handlers.
+ */
+export function assertPasswordPolicy(password: string): void {
+  const result = validatePassword(password);
+  if (!result.ok) {
+    const err = Object.assign(new Error(result.reason), {
+      code: result.code,
+    });
+    throw err;
+  }
+}

--- a/apps/api/src/user-repository.ts
+++ b/apps/api/src/user-repository.ts
@@ -1,0 +1,53 @@
+import type { AuthSession, AuthUser } from "@chordially/types";
+
+// ── Contract ──────────────────────────────────────────────────────────────────
+
+export interface UserRepository {
+  findByEmail(email: string): (AuthUser & { passwordHash: string }) | undefined;
+  findById(id: string): AuthUser | undefined;
+  emailTaken(email: string): boolean;
+  create(user: AuthUser & { passwordHash: string }): AuthUser;
+  listAll(): AuthUser[];
+}
+
+export interface SessionRepository {
+  save(session: AuthSession): void;
+  find(token: string): AuthSession | undefined;
+  remove(token: string): boolean;
+  clear(): void;
+}
+
+// ── In-memory implementations ─────────────────────────────────────────────────
+
+export class InMemoryUserRepository implements UserRepository {
+  private store = new Map<string, AuthUser & { passwordHash: string }>();
+
+  findByEmail(email: string) { return this.store.get(email); }
+
+  findById(id: string) {
+    return [...this.store.values()].find((u) => u.id === id);
+  }
+
+  emailTaken(email: string) { return this.store.has(email); }
+
+  create(user: AuthUser & { passwordHash: string }): AuthUser {
+    this.store.set(user.email, user);
+    const { passwordHash: _, ...safe } = user;
+    return safe;
+  }
+
+  listAll(): AuthUser[] {
+    return [...this.store.values()].map(({ passwordHash: _, ...u }) => u);
+  }
+
+  reset() { this.store.clear(); }
+}
+
+export class InMemorySessionRepository implements SessionRepository {
+  private store = new Map<string, AuthSession>();
+
+  save(session: AuthSession) { this.store.set(session.token, session); }
+  find(token: string) { return this.store.get(token); }
+  remove(token: string) { return this.store.delete(token); }
+  clear() { this.store.clear(); }
+}

--- a/packages/types/src/auth-contracts.ts
+++ b/packages/types/src/auth-contracts.ts
@@ -1,0 +1,52 @@
+import type { AuthSession, AuthUser } from "./index.js";
+
+// ── Request shapes ────────────────────────────────────────────────────────────
+
+export type RegisterRequest = {
+  email: string;
+  password: string;
+  displayName: string;
+};
+
+export type LoginRequest = {
+  email: string;
+  password: string;
+};
+
+export type LogoutRequest = {
+  token: string;
+};
+
+// ── Response envelopes ────────────────────────────────────────────────────────
+
+export type RegisterResponse = {
+  message: string;
+  user: AuthUser;
+};
+
+export type LoginResponse = {
+  message: string;
+  session: AuthSession;
+};
+
+export type LogoutResponse = {
+  message: string;
+};
+
+export type SessionResponse = {
+  session: AuthSession | null;
+};
+
+// ── Error envelope ────────────────────────────────────────────────────────────
+
+export type AuthErrorCode =
+  | "DUPLICATE_EMAIL"
+  | "INVALID_CREDENTIALS"
+  | "INVALID_SESSION"
+  | "POLICY_VIOLATION"
+  | "MALFORMED_REQUEST";
+
+export type AuthErrorResponse = {
+  error: AuthErrorCode;
+  message: string;
+};


### PR DESCRIPTION
Closes #310, closes #311, closes #312, closes #313

- **#310** – Added typed request/response envelopes and a stable `AuthErrorCode` union to `packages/types` so route handlers no longer leak raw objects.
- **#311** – Centralised password validation in `password-policy.ts`; rules cover length, whitespace, uppercase, digit, and special-character requirements with machine-readable rejection codes.
- **#312** – Introduced `UserRepository` and `SessionRepository` interfaces with in-memory implementations so auth logic no longer touches a raw `Map` directly.
- **#313** – Added a `ScryptHasher` adapter (Node built-in `crypto`, no extra deps) that hashes on write and uses `timingSafeEqual` on verify.