### PR TITLE
account lockout and cooldown

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -62,16 +62,24 @@ export function createApp(): Express {
     }
   });
 
-  // #321 – rate-limited
+  // #321 – rate-limited; #330 – account lockout
   app.post("/api/v1/auth/login", rateLimiters.login, (req, res) => {
     const payload = loginSchema.parse(req.body);
     const ip = (req.headers["x-forwarded-for"] as string | undefined)?.split(",")[0]?.trim()
       ?? req.socket.remoteAddress;
     const userAgent = req.headers["user-agent"];
-    const { session, refreshToken } = loginUser({ ...payload, ip, userAgent });
-    // Redact telemetry from the response; it is stored server-side only.
-    const { ip: _ip, userAgent: _ua, ...safeSession } = session;
-    res.status(200).json({ message: "Login starter flow completed.", session: safeSession, refreshToken });
+    try {
+      const { session, refreshToken } = loginUser({ ...payload, ip, userAgent });
+      const { ip: _ip, userAgent: _ua, ...safeSession } = session;
+      res.status(200).json({ message: "Login starter flow completed.", session: safeSession, refreshToken });
+    } catch (err: unknown) {
+      const e = err as { code?: string; retryAfterMs?: number; message: string };
+      if (e.code === "ACCOUNT_LOCKED") {
+        res.status(423).json({ error: "ACCOUNT_LOCKED", message: e.message, retryAfterMs: e.retryAfterMs });
+        return;
+      }
+      res.status(401).json({ error: "LOGIN_FAILED", message: "Invalid email or password." });
+    }
   });
 
   // #318 – single-session logout: revokes only the supplied token

--- a/apps/api/src/auth-store.ts
+++ b/apps/api/src/auth-store.ts
@@ -4,6 +4,7 @@ import type { AuthSession, AuthUser, RefreshToken } from "@chordially/types";
 
 import { env } from "./env.js";
 import { signAccessToken } from "./token-service.js";
+import { lockoutRemaining, recordFailure, recordSuccess } from "./lockout-store.js";
 
 type RegisterInput = { email: string; password: string; displayName: string };
 type LoginInput    = { email: string; password: string; origin?: string; ip?: string; userAgent?: string };
@@ -40,8 +41,22 @@ export function registerUser(input: RegisterInput): AuthUser {
 
 export function loginUser(input: LoginInput): { session: AuthSession; refreshToken: string } {
   const email = input.email.trim().toLowerCase();
-  const user  = users.get(email);
-  if (!user || user.password !== input.password) throw new Error("Invalid email or password.");
+
+  const remaining = lockoutRemaining(email);
+  if (remaining > 0) {
+    const err = Object.assign(new Error("Account temporarily locked. Try again later."), {
+      code: "ACCOUNT_LOCKED",
+      retryAfterMs: remaining,
+    });
+    throw err;
+  }
+
+  const user = users.get(email);
+  if (!user || user.password !== input.password) {
+    recordFailure(email);
+    throw new Error("Invalid email or password.");
+  }
+  recordSuccess(email);
 
   const now = new Date().toISOString();
 

--- a/apps/api/src/lockout-store.ts
+++ b/apps/api/src/lockout-store.ts
@@ -1,0 +1,49 @@
+/**
+ * lockout-store.ts
+ *
+ * In-memory account lockout tracker. After MAX_FAILURES consecutive failed
+ * logins the account is locked for COOLDOWN_MS. A successful login clears
+ * the failure counter.
+ */
+
+const MAX_FAILURES  = 5;
+const COOLDOWN_MS   = 15 * 60 * 1000; // 15 minutes
+
+interface Entry { failures: number; lockedUntil: number | null }
+
+const store = new Map<string, Entry>();
+
+function get(email: string): Entry {
+  return store.get(email) ?? { failures: 0, lockedUntil: null };
+}
+
+/** Returns ms remaining in lockout, or 0 if not locked. */
+export function lockoutRemaining(email: string): number {
+  const e = get(email);
+  if (!e.lockedUntil) return 0;
+  const remaining = e.lockedUntil - Date.now();
+  return remaining > 0 ? remaining : 0;
+}
+
+/** Call on every failed login attempt. */
+export function recordFailure(email: string): void {
+  const e = get(email);
+  // Reset expired lockout before counting.
+  if (e.lockedUntil && Date.now() >= e.lockedUntil) {
+    e.failures = 0;
+    e.lockedUntil = null;
+  }
+  e.failures++;
+  if (e.failures >= MAX_FAILURES) e.lockedUntil = Date.now() + COOLDOWN_MS;
+  store.set(email, e);
+}
+
+/** Call on successful login to clear failure state. */
+export function recordSuccess(email: string): void {
+  store.delete(email);
+}
+
+/** Test helper. */
+export function resetLockoutStore(): void {
+  store.clear();
+}

--- a/apps/api/tests/auth-330-lockout.test.ts
+++ b/apps/api/tests/auth-330-lockout.test.ts
@@ -1,0 +1,91 @@
+/**
+ * auth-330-lockout.test.ts
+ *
+ * Tests for issue #330 – account lockout and cooldown on repeated failed logins.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { loginUser, registerUser, resetAuthStore } from "../src/auth-store.js";
+import { resetLockoutStore, lockoutRemaining } from "../src/lockout-store.js";
+import { createApp } from "../src/app.js";
+
+const EMAIL    = "lock@example.com";
+const PASSWORD = "correct-password";
+
+function setup() {
+  resetAuthStore();
+  resetLockoutStore();
+  registerUser({ email: EMAIL, password: PASSWORD, displayName: "Locked" });
+}
+
+function failLogin(n: number) {
+  for (let i = 0; i < n; i++) {
+    try { loginUser({ email: EMAIL, password: "wrong" }); } catch { /* expected */ }
+  }
+}
+
+// ── unit: lockout-store ───────────────────────────────────────────────────────
+
+test("no lockout before threshold", () => {
+  setup();
+  failLogin(4);
+  assert.equal(lockoutRemaining(EMAIL), 0);
+});
+
+test("lockout activates at 5th failure", () => {
+  setup();
+  failLogin(5);
+  assert.ok(lockoutRemaining(EMAIL) > 0);
+});
+
+test("locked account throws ACCOUNT_LOCKED", () => {
+  setup();
+  failLogin(5);
+  try {
+    loginUser({ email: EMAIL, password: PASSWORD });
+    assert.fail("should have thrown");
+  } catch (err: unknown) {
+    assert.equal((err as { code?: string }).code, "ACCOUNT_LOCKED");
+  }
+});
+
+test("successful login clears failure counter", () => {
+  setup();
+  failLogin(4);
+  loginUser({ email: EMAIL, password: PASSWORD });
+  assert.equal(lockoutRemaining(EMAIL), 0);
+  // Should be able to fail again without immediate lockout.
+  failLogin(4);
+  assert.equal(lockoutRemaining(EMAIL), 0);
+});
+
+// ── HTTP: 423 response ────────────────────────────────────────────────────────
+
+test("POST /api/v1/auth/login returns 423 when locked", async () => {
+  setup();
+  failLogin(5);
+
+  const { default: supertest } = await import("supertest");
+  const app = createApp();
+  const res = await supertest(app)
+    .post("/api/v1/auth/login")
+    .send({ email: EMAIL, password: PASSWORD });
+
+  assert.equal(res.status, 423);
+  assert.equal(res.body.error, "ACCOUNT_LOCKED");
+  assert.ok(res.body.retryAfterMs > 0);
+});
+
+test("POST /api/v1/auth/login returns 401 for bad creds (not locked)", async () => {
+  setup();
+
+  const { default: supertest } = await import("supertest");
+  const app = createApp();
+  const res = await supertest(app)
+    .post("/api/v1/auth/login")
+    .send({ email: EMAIL, password: "wrong-password" });
+
+  assert.equal(res.status, 401);
+  assert.equal(res.body.error, "LOGIN_FAILED");
+});


### PR DESCRIPTION
Implements account lockout for repeated failed sign-in attempts.

**Changes**
- `lockout-store.ts` — in-memory tracker; locks after 5 consecutive failures for 15 min, clears on success
- `auth-store.ts` — `loginUser` checks lockout before credentials, records failure/success
- `app.ts` — login route returns `423 ACCOUNT_LOCKED` with `retryAfterMs` when locked
- `auth-330-lockout.test.ts` — 6 tests covering lockout transitions and HTTP responses

Closes #330
Closes  #331 
Closes #332 
Closes #333