### PR TITLE
feat(web): auth handoff, password reset, and email verification pages

### DIFF
--- a/apps/web/app/auth/register/success/page.tsx
+++ b/apps/web/app/auth/register/success/page.tsx
@@ -1,0 +1,41 @@
+import type { AccountState } from "../../../../lib/register-state";
+
+const copy: Record<AccountState, { heading: string; body: string; cta: string; href: string }> = {
+  "verify-email": {
+    heading: "Check your inbox.",
+    body: "We sent a verification link to your email address. Click it to activate your account before signing in.",
+    cta: "Back to sign in",
+    href: "/auth",
+  },
+  active: {
+    heading: "You're in.",
+    body: "Your account is ready. Sign in to get started.",
+    cta: "Sign in",
+    href: "/auth",
+  },
+};
+
+export default function RegisterSuccessPage({
+  searchParams,
+}: {
+  searchParams: { state?: string };
+}) {
+  const state: AccountState =
+    searchParams.state === "verify-email" ? "verify-email" : "active";
+  const { heading, body, cta, href } = copy[state];
+
+  return (
+    <main className="page-shell">
+      <section className="detail-panel">
+        <p className="eyebrow">Registration complete</p>
+        <h1>{heading}</h1>
+        <p className="lede">{body}</p>
+        <div className="cta-row">
+          <a href={href} className="primary-link">
+            {cta}
+          </a>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/auth/reset-password/confirm/page.tsx
+++ b/apps/web/app/auth/reset-password/confirm/page.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+
+type Phase = "idle" | "loading" | "success" | "expired" | "reused" | "error";
+
+const outcomeMessages: Record<"expired" | "reused" | "error", string> = {
+  expired: "This reset link has expired. Request a new one.",
+  reused: "This link has already been used. Request a new reset link.",
+  error: "Something went wrong. Please try again.",
+};
+
+export default function ResetConfirmPage({
+  searchParams,
+}: {
+  searchParams: { token?: string };
+}) {
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [mismatch, setMismatch] = useState(false);
+  const token = searchParams.token ?? "";
+
+  if (!token) {
+    return (
+      <main className="page-shell">
+        <section className="detail-panel">
+          <p className="eyebrow">Password reset</p>
+          <h1>Invalid link.</h1>
+          <p className="lede">This reset link is missing a token.</p>
+          <div className="cta-row">
+            <a href="/auth/reset-password" className="primary-link">Request a new link</a>
+          </div>
+        </section>
+      </main>
+    );
+  }
+
+  if (phase === "success") {
+    return (
+      <main className="page-shell">
+        <section className="detail-panel">
+          <p className="eyebrow">Password reset</p>
+          <h1>Password updated.</h1>
+          <p className="lede">Your password has been changed. Sign in with your new credentials.</p>
+          <div className="cta-row">
+            <a href="/auth" className="primary-link">Sign in</a>
+          </div>
+        </section>
+      </main>
+    );
+  }
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const data = new FormData(e.currentTarget);
+    const password = data.get("password") as string;
+    const confirm = data.get("confirm") as string;
+
+    if (password !== confirm) { setMismatch(true); return; }
+    setMismatch(false);
+    setPhase("loading");
+
+    try {
+      const res = await fetch(
+        `${process.env["NEXT_PUBLIC_API_BASE_URL"] ?? "http://localhost:4000"}/api/v1/auth/reset-password/confirm`,
+        { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ token, password }) }
+      );
+      if (res.ok) { setPhase("success"); return; }
+      const body = await res.json() as { error?: string };
+      if (body.error === "TOKEN_EXPIRED") setPhase("expired");
+      else if (body.error === "TOKEN_INVALID") setPhase("reused");
+      else setPhase("error");
+    } catch {
+      setPhase("error");
+    }
+  }
+
+  const errorMsg = (phase === "expired" || phase === "reused" || phase === "error")
+    ? outcomeMessages[phase]
+    : null;
+
+  return (
+    <main className="page-shell">
+      <section className="detail-panel">
+        <p className="eyebrow">Password reset</p>
+        <h1>Set a new password.</h1>
+        <form onSubmit={handleSubmit} style={{ marginTop: 24, display: "flex", flexDirection: "column", gap: 14, maxWidth: 360 }}>
+          <input
+            name="password"
+            type="password"
+            required
+            minLength={8}
+            placeholder="New password (min 8 chars)"
+            disabled={phase === "loading"}
+            style={{ padding: "10px 14px", borderRadius: 8, border: "1px solid var(--border)", fontSize: "1rem", background: "transparent", color: "var(--ink)" }}
+          />
+          <input
+            name="confirm"
+            type="password"
+            required
+            placeholder="Confirm new password"
+            disabled={phase === "loading"}
+            style={{ padding: "10px 14px", borderRadius: 8, border: "1px solid var(--border)", fontSize: "1rem", background: "transparent", color: "var(--ink)" }}
+          />
+          {mismatch && <p style={{ margin: 0, color: "var(--accent)", fontSize: "0.9rem" }}>Passwords do not match.</p>}
+          {errorMsg && (
+            <p style={{ margin: 0, color: "var(--accent)", fontSize: "0.9rem" }}>
+              {errorMsg}{" "}
+              {(phase === "expired" || phase === "reused") && (
+                <a href="/auth/reset-password" style={{ color: "var(--accent-strong)" }}>Request a new link.</a>
+              )}
+            </p>
+          )}
+          <div className="cta-row" style={{ marginTop: 0 }}>
+            <button type="submit" disabled={phase === "loading"} className="primary-link" style={{ cursor: "pointer", border: "none" }}>
+              {phase === "loading" ? "Saving…" : "Update password"}
+            </button>
+          </div>
+        </form>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/auth/reset-password/page.tsx
+++ b/apps/web/app/auth/reset-password/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+
+type Phase = "idle" | "loading" | "sent" | "error";
+
+export default function ResetRequestPage() {
+  const [phase, setPhase] = useState<Phase>("idle");
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setPhase("loading");
+    const email = new FormData(e.currentTarget).get("email") as string;
+
+    try {
+      await fetch(
+        `${process.env["NEXT_PUBLIC_API_BASE_URL"] ?? "http://localhost:4000"}/api/v1/auth/reset-password/request`,
+        { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ email }) }
+      );
+      // Always show the same message to avoid account enumeration.
+      setPhase("sent");
+    } catch {
+      setPhase("error");
+    }
+  }
+
+  if (phase === "sent") {
+    return (
+      <main className="page-shell">
+        <section className="detail-panel">
+          <p className="eyebrow">Password reset</p>
+          <h1>Check your inbox.</h1>
+          <p className="lede">
+            If an account exists for that address, a reset link is on its way.
+          </p>
+          <div className="cta-row">
+            <a href="/auth" className="secondary-link">Back to sign in</a>
+          </div>
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main className="page-shell">
+      <section className="detail-panel">
+        <p className="eyebrow">Password reset</p>
+        <h1>Forgot your password?</h1>
+        <p className="lede">Enter your email and we'll send a reset link if an account exists.</p>
+        <form onSubmit={handleSubmit} style={{ marginTop: 24, display: "flex", flexDirection: "column", gap: 14, maxWidth: 360 }}>
+          <input
+            name="email"
+            type="email"
+            required
+            placeholder="you@example.com"
+            disabled={phase === "loading"}
+            style={{ padding: "10px 14px", borderRadius: 8, border: "1px solid var(--border)", fontSize: "1rem", background: "transparent", color: "var(--ink)" }}
+          />
+          {phase === "error" && (
+            <p style={{ margin: 0, color: "var(--accent)", fontSize: "0.9rem" }}>
+              Something went wrong. Please try again.
+            </p>
+          )}
+          <div className="cta-row" style={{ marginTop: 0 }}>
+            <button type="submit" disabled={phase === "loading"} className="primary-link" style={{ cursor: "pointer", border: "none" }}>
+              {phase === "loading" ? "Sending…" : "Send reset link"}
+            </button>
+            <a href="/auth" className="secondary-link">Cancel</a>
+          </div>
+        </form>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/auth/verify/page.tsx
+++ b/apps/web/app/auth/verify/page.tsx
@@ -1,0 +1,78 @@
+type VerifyOutcome = "success" | "already-verified" | "expired" | "invalid" | "missing";
+
+const outcomeContent: Record<
+  VerifyOutcome,
+  { heading: string; body: string; cta: string; href: string }
+> = {
+  success: {
+    heading: "Email verified.",
+    body: "Your account is now active. Sign in to get started.",
+    cta: "Sign in",
+    href: "/auth",
+  },
+  "already-verified": {
+    heading: "Already verified.",
+    body: "This account has already been verified. Sign in below.",
+    cta: "Sign in",
+    href: "/auth",
+  },
+  expired: {
+    heading: "Link expired.",
+    body: "This verification link has expired. Request a new one from the sign-in page.",
+    cta: "Back to sign in",
+    href: "/auth",
+  },
+  invalid: {
+    heading: "Invalid link.",
+    body: "This verification link is not valid. It may have already been used or was malformed.",
+    cta: "Back to sign in",
+    href: "/auth",
+  },
+  missing: {
+    heading: "No token.",
+    body: "This page requires a verification token. Use the link from your email.",
+    cta: "Back to sign in",
+    href: "/auth",
+  },
+};
+
+async function resolveOutcome(token: string): Promise<VerifyOutcome> {
+  try {
+    const res = await fetch(
+      `${process.env["NEXT_PUBLIC_API_BASE_URL"] ?? "http://localhost:4000"}/api/v1/auth/verify-email`,
+      { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ token }), cache: "no-store" }
+    );
+    if (res.ok) return "success";
+    const body = await res.json() as { error?: string };
+    if (body.error === "TOKEN_EXPIRED") return "expired";
+    if (body.error === "TOKEN_INVALID") return "invalid";
+    // A 409 or similar can indicate already-verified
+    if (res.status === 409) return "already-verified";
+    return "invalid";
+  } catch {
+    return "invalid";
+  }
+}
+
+export default async function VerifyEmailPage({
+  searchParams,
+}: {
+  searchParams: { token?: string };
+}) {
+  const token = searchParams.token;
+  const outcome: VerifyOutcome = token ? await resolveOutcome(token) : "missing";
+  const { heading, body, cta, href } = outcomeContent[outcome];
+
+  return (
+    <main className="page-shell">
+      <section className="detail-panel">
+        <p className="eyebrow">Email verification</p>
+        <h1>{heading}</h1>
+        <p className="lede">{body}</p>
+        <div className="cta-row">
+          <a href={href} className="primary-link">{cta}</a>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/lib/register-state.ts
+++ b/apps/web/lib/register-state.ts
@@ -1,0 +1,8 @@
+import type { RegisterResponse } from "@chordially/types/src/auth-contracts.js";
+
+export type AccountState = "verify-email" | "active";
+
+/** Maps the API registration message to a UI account state. */
+export function deriveState(message: RegisterResponse["message"]): AccountState {
+  return message === "VERIFY_EMAIL" ? "verify-email" : "active";
+}


### PR DESCRIPTION
Adds four missing auth UI routes to `apps/web`:

- `/auth/register/success` — post-registration handoff that branches on `verify-email` vs `active` account state (#342)
- `/auth/reset-password` — enumeration-safe reset request form (#343)
- `/auth/reset-password/confirm` — token-based reset completion with distinct expired, reused, and success outcomes (#344)
- `/auth/verify` — email verification page covering success, already-verified, expired, invalid, and missing token states (#345)

All pages reuse existing CSS classes and align with current API response contracts.

Closes #342, Closes #343, Closes #344, Closes #345