### PR TITLE
Mobile auth foundation pass: deep-link callbacks, reusable form fields, validation states, and restricted-account UX

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,9 +1,26 @@
-import { useState } from "react";
-import { SafeAreaView, ScrollView, StyleSheet, Text, View, TextInput, Pressable } from "react-native";
+import { useMemo, useState } from "react";
+import { Linking, SafeAreaView, ScrollView, StyleSheet, Text, View, TextInput, Pressable } from "react-native";
 
 import { mobileConfig } from "./src/config";
 
-type Screen = "home" | "resetRequest" | "resetComplete" | "verifyPending";
+type Screen = "home" | "resetRequest" | "resetComplete" | "verifyPending" | "restricted";
+
+function AuthField(props: {
+  label: string;
+  value: string;
+  onChangeText: (t: string) => void;
+  placeholder: string;
+  secure?: boolean;
+  error?: string;
+}) {
+  return (
+    <View style={{ gap: 4 }}>
+      <Text>{props.label}</Text>
+      <TextInput style={styles.input} value={props.value} onChangeText={props.onChangeText} placeholder={props.placeholder} secureTextEntry={props.secure} />
+      {props.error ? <Text style={{ color: "#a83d1b" }}>{props.error}</Text> : null}
+    </View>
+  );
+}
 
 export default function App() {
   const [screen, setScreen] = useState<Screen>("home");
@@ -12,6 +29,10 @@ export default function App() {
   const [password, setPassword] = useState("");
   const [msg, setMsg] = useState("");
   const [signedIn, setSignedIn] = useState(true);
+  const [pending, setPending] = useState(false);
+  const [serverError, setServerError] = useState("");
+  const emailError = useMemo(() => (email && !email.includes("@") ? "Enter a valid email." : ""), [email]);
+  const passwordError = useMemo(() => (password && password.length < 8 ? "Password must be at least 8 characters." : ""), [password]);
 
   async function api(path: string, body: Record<string, string>) {
     const res = await fetch(`${mobileConfig.apiBaseUrl}${path}`, {
@@ -23,36 +44,69 @@ export default function App() {
   }
 
   async function requestReset() {
+    if (emailError) return;
+    setPending(true);
     try {
       const res = await api("/auth/password-reset/request", { email });
       setMsg(res.ok ? "If that account exists, reset instructions were sent." : "Unable to request reset.");
+      setServerError(res.ok ? "" : "Request failed");
     } catch {
       setMsg("Network error while requesting reset.");
+      setServerError("Network failure");
     }
+    setPending(false);
   }
 
   async function completeReset() {
+    if (passwordError) return;
+    setPending(true);
     try {
       const res = await api("/auth/password-reset/complete", { token, password });
       setMsg(res.ok ? "Password updated. Continue to sign in." : "Reset token is invalid or expired.");
+      setServerError(res.ok ? "" : "Reset failed");
     } catch {
       setMsg("Network error while completing reset.");
+      setServerError("Network failure");
     }
+    setPending(false);
   }
 
   async function resendVerification() {
+    setPending(true);
     try {
       const res = await api("/auth/verify-email", { token });
       setMsg(res.ok ? "Verification updated." : "Verification token is invalid or expired.");
+      setServerError(res.ok ? "" : "Verification failed");
     } catch {
       setMsg("Network error while verifying.");
+      setServerError("Network failure");
     }
+    setPending(false);
   }
 
   function logout() {
     setSignedIn(false);
     setScreen("home");
     setMsg("Signed out cleanly.");
+  }
+
+  async function parseDeepLink() {
+    const url = await Linking.getInitialURL();
+    if (!url) return;
+    try {
+      const parsed = new URL(url);
+      if (parsed.pathname.includes("verify")) {
+        setScreen("verifyPending");
+        setToken(parsed.searchParams.get("token") ?? "");
+      } else if (parsed.pathname.includes("reset")) {
+        setScreen("resetComplete");
+        setToken(parsed.searchParams.get("token") ?? "");
+      } else {
+        setMsg("Unsupported auth callback link.");
+      }
+    } catch {
+      setMsg("Malformed auth callback link.");
+    }
   }
 
   return (
@@ -82,22 +136,26 @@ export default function App() {
             <Pressable style={styles.btn} onPress={() => setScreen("verifyPending")}><Text>Verify Pending</Text></Pressable>
             <Pressable style={styles.btn} onPress={logout}><Text>Logout</Text></Pressable>
           </View>
+          <View style={styles.row}>
+            <Pressable style={styles.btn} onPress={parseDeepLink}><Text>Parse auth deep link</Text></Pressable>
+            <Pressable style={styles.btn} onPress={() => setScreen("restricted")}><Text>Restricted Account</Text></Pressable>
+          </View>
         </View>
 
         {screen === "resetRequest" && (
           <View style={styles.panel}>
             <Text style={styles.panelTitle}>Password reset request</Text>
-            <TextInput style={styles.input} value={email} onChangeText={setEmail} placeholder="Email" />
-            <Pressable style={styles.btn} onPress={requestReset}><Text>Submit request</Text></Pressable>
+            <AuthField label="Email" value={email} onChangeText={setEmail} placeholder="Email" error={emailError} />
+            <Pressable style={styles.btn} onPress={requestReset} disabled={pending}><Text>{pending ? "Submitting..." : "Submit request"}</Text></Pressable>
           </View>
         )}
 
         {screen === "resetComplete" && (
           <View style={styles.panel}>
             <Text style={styles.panelTitle}>Password reset completion</Text>
-            <TextInput style={styles.input} value={token} onChangeText={setToken} placeholder="Reset token" />
-            <TextInput style={styles.input} value={password} onChangeText={setPassword} placeholder="New password" />
-            <Pressable style={styles.btn} onPress={completeReset}><Text>Complete reset</Text></Pressable>
+            <AuthField label="Reset token" value={token} onChangeText={setToken} placeholder="Reset token" />
+            <AuthField label="New password" value={password} onChangeText={setPassword} placeholder="New password" secure error={passwordError} />
+            <Pressable style={styles.btn} onPress={completeReset} disabled={pending}><Text>{pending ? "Submitting..." : "Complete reset"}</Text></Pressable>
           </View>
         )}
 
@@ -105,10 +163,17 @@ export default function App() {
           <View style={styles.panel}>
             <Text style={styles.panelTitle}>Verification pending</Text>
             <Text style={styles.panelBody}>Account still needs verification.</Text>
-            <TextInput style={styles.input} value={token} onChangeText={setToken} placeholder="Verification token" />
-            <Pressable style={styles.btn} onPress={resendVerification}><Text>Submit / resend verification</Text></Pressable>
+            <AuthField label="Verification token" value={token} onChangeText={setToken} placeholder="Verification token" />
+            <Pressable style={styles.btn} onPress={resendVerification} disabled={pending}><Text>{pending ? "Submitting..." : "Submit / resend verification"}</Text></Pressable>
           </View>
         )}
+        {screen === "restricted" && (
+          <View style={styles.panel}>
+            <Text style={styles.panelTitle}>Restricted account</Text>
+            <Text style={styles.panelBody}>This account is disabled or banned. Contact project maintainers for recovery support.</Text>
+          </View>
+        )}
+        {serverError ? <Text style={{ color: "#a83d1b" }}>{serverError}</Text> : null}
       </ScrollView>
     </SafeAreaView>
   );


### PR DESCRIPTION
## Summary
This PR adds a compact mobile auth foundation for AUTH-061..064 (issues #370..#373).

## Included
- Added reusable auth form primitive () with consistent label/error/secure-entry behavior.
- Added inline validation and pending submit-state handling for auth actions.
- Added deep-link parsing path for verification/reset callback entry points.
- Added dedicated restricted-account screen state with recovery guidance.

## Notes
- Implementation remains intentionally lightweight and single-file to keep iteration fast.

Closes #370
Closes #371
Closes #372
Closes #373