### PR TITLE
feat(web): intentional unauthorized route UX

### DIFF
--- a/apps/web/app/unauthorized/page.tsx
+++ b/apps/web/app/unauthorized/page.tsx
@@ -1,0 +1,77 @@
+import { parseUnauthorizedReason, type UnauthorizedReason } from "../../lib/unauthorized";
+
+type UnauthorizedCopy = {
+  eyebrow: string;
+  heading: string;
+  body: string;
+  primary: { label: string; href: string };
+  secondary?: { label: string; href: string };
+};
+
+function copyFor(reason: UnauthorizedReason, next?: string): UnauthorizedCopy {
+  const safeNext = typeof next === "string" && next.startsWith("/") ? next : undefined;
+
+  switch (reason) {
+    case "signed-out":
+      return {
+        eyebrow: "Unauthorized",
+        heading: "You need to sign in.",
+        body: "This page is protected. Sign in to continue, or head back to the starter home.",
+        primary: { label: "Go to sign in", href: "/auth" },
+        secondary: safeNext ? { label: "Back to previous page", href: safeNext } : { label: "Go home", href: "/" },
+      };
+    case "expired":
+      return {
+        eyebrow: "Session expired",
+        heading: "Your session timed out.",
+        body: "For your security, we signed you out after inactivity. Sign in again to continue.",
+        primary: { label: "Sign in again", href: "/auth" },
+        secondary: safeNext ? { label: "Return to where you were", href: safeNext } : { label: "Go home", href: "/" },
+      };
+    case "forbidden":
+      return {
+        eyebrow: "Access denied",
+        heading: "You’re signed in, but don’t have permission.",
+        body: "The account you used doesn’t have access to this route yet. You can switch accounts or return home.",
+        primary: { label: "Switch account", href: "/auth" },
+        secondary: { label: "Go home", href: "/" },
+      };
+    default:
+      return {
+        eyebrow: "Unauthorized",
+        heading: "We can’t open that page.",
+        body: "The app couldn’t confirm you have an active session for this route. Try signing in again.",
+        primary: { label: "Go to sign in", href: "/auth" },
+        secondary: { label: "Go home", href: "/" },
+      };
+  }
+}
+
+export default function UnauthorizedPage({
+  searchParams,
+}: {
+  searchParams: { reason?: string; next?: string };
+}) {
+  const reason = parseUnauthorizedReason(searchParams.reason);
+  const { eyebrow, heading, body, primary, secondary } = copyFor(reason, searchParams.next);
+
+  return (
+    <main className="page-shell">
+      <section className="detail-panel">
+        <p className="eyebrow">{eyebrow}</p>
+        <h1>{heading}</h1>
+        <p className="lede">{body}</p>
+        <div className="cta-row">
+          <a className="primary-link" href={primary.href}>
+            {primary.label}
+          </a>
+          {secondary ? (
+            <a className="secondary-link" href={secondary.href}>
+              {secondary.label}
+            </a>
+          ) : null}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/lib/unauthorized.ts
+++ b/apps/web/lib/unauthorized.ts
@@ -1,0 +1,28 @@
+export type UnauthorizedReason = "signed-out" | "expired" | "forbidden" | "unknown";
+
+export function mapAuthErrorToUnauthorizedReason(error: unknown): UnauthorizedReason {
+  if (typeof error !== "string") return "unknown";
+  if (error === "FORBIDDEN") return "forbidden";
+  if (error === "TOKEN_EXPIRED") return "expired";
+  if (error === "TOKEN_INVALID" || error === "INVALID_SESSION") return "signed-out";
+  return "unknown";
+}
+
+type UnauthorizedUrlOptions = {
+  reason: UnauthorizedReason;
+  next?: string;
+};
+
+export function createUnauthorizedUrl({ reason, next }: UnauthorizedUrlOptions): string {
+  const params = new URLSearchParams();
+  if (reason !== "unknown") params.set("reason", reason);
+  if (next) params.set("next", next);
+  const query = params.toString();
+  return query ? `/unauthorized?${query}` : "/unauthorized";
+}
+
+export function parseUnauthorizedReason(value: unknown): UnauthorizedReason {
+  if (typeof value !== "string") return "unknown";
+  if (value === "signed-out" || value === "expired" || value === "forbidden") return value;
+  return "unknown";
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "../../packages/config/tsconfig.base.json",
   "compilerOptions": {
     "jsx": "preserve",
-    "lib": ["dom", "dom.iterable", "es2020"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es2020"
+    ],
     "allowJs": false,
     "incremental": true,
     "isolatedModules": true,
@@ -10,8 +14,16 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "noEmit": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
Closes #346

Closes #347
Closes #348
Closes #349

## Summary
- Adds `/unauthorized` as a dedicated UX for blocked, missing, or expired sessions
- Differentiates signed-out vs session-expired vs forbidden states via query params (`reason`)
- Provides a small helper (`createUnauthorizedUrl`) for reuse by future protected routes

## Testing
- pnpm --filter @chordially/web lint
- pnpm --filter @chordially/web typecheck
- pnpm --filter @chordially/web build