### PR TITLE
feat(auth): add wallet auth telemetry events

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,4 +1,5 @@
 import express, { type Express, type NextFunction, type Request, type Response } from "express";
+import { WALLET_AUTH_TELEMETRY_EVENTS } from "@chordially/types";
 import { z, ZodError } from "zod";
 
 import { env } from "./env.js";
@@ -19,6 +20,7 @@ import { rateLimiters } from "./rate-limiter.js";
 import { requestVerification, confirmVerification } from "./verification-store.js";
 import { requestPasswordReset, consumeResetToken } from "./reset-store.js";
 import { registerContract, openApiRouter } from "./lib/openapi-generator.js";
+import { emitWalletAuthTelemetry } from "./telemetry.js";
 
 // ── #334 – OpenAPI contracts for auth endpoints ───────────────────────────
 registerContract({
@@ -118,10 +120,22 @@ export function createApp(): Express {
         ?? req.socket.remoteAddress;
       const userAgent = req.headers["user-agent"];
       const { session, refreshToken } = loginUser({ ...payload, ip, userAgent });
+      emitWalletAuthTelemetry({
+        event: WALLET_AUTH_TELEMETRY_EVENTS.walletLinkSucceeded,
+        outcome: "success",
+        boundary: "api.auth.login",
+        subjectId: session.userId,
+      });
       // Redact telemetry from the response; it is stored server-side only.
       const { ip: _ip, userAgent: _ua, ...safeSession } = session;
       res.status(200).json({ message: "Login starter flow completed.", session: safeSession, refreshToken });
     } catch (err) {
+      emitWalletAuthTelemetry({
+        event: WALLET_AUTH_TELEMETRY_EVENTS.walletAuthFailed,
+        outcome: "failure",
+        boundary: "api.auth.login",
+        reason: err instanceof AuthServiceError ? err.code : "MALFORMED_REQUEST",
+      });
       next(err);
     }
   });
@@ -130,6 +144,12 @@ export function createApp(): Express {
   app.post("/api/v1/auth/logout", (req, res) => {
     const { token } = logoutSchema.parse(req.body);
     const revoked = logoutUser(token);
+    emitWalletAuthTelemetry({
+      event: WALLET_AUTH_TELEMETRY_EVENTS.walletLinkRevoked,
+      outcome: "revocation",
+      boundary: "api.auth.logout",
+      sessionsRevoked: revoked ? 1 : 0,
+    });
     res.status(200).json({
       message: revoked ? "Session revoked." : "Session was already absent.",
       sessionsRevoked: revoked ? 1 : 0,
@@ -140,6 +160,13 @@ export function createApp(): Express {
   app.post("/api/v1/auth/logout-all", requireAuth, (req, res) => {
     const session = res.locals["session"] as import("@chordially/types").AuthSession;
     const count = logoutAllSessions(session.userId);
+    emitWalletAuthTelemetry({
+      event: WALLET_AUTH_TELEMETRY_EVENTS.walletLinkRevoked,
+      outcome: "revocation",
+      boundary: "api.auth.logout_all",
+      subjectId: session.userId,
+      sessionsRevoked: count,
+    });
     res.status(200).json({
       message: "All sessions revoked.",
       sessionsRevoked: count,

--- a/apps/api/src/telemetry.ts
+++ b/apps/api/src/telemetry.ts
@@ -1,0 +1,25 @@
+import type { WalletAuthTelemetryPayload } from "@chordially/types";
+
+type ApiWalletAuthTelemetryInput =
+  Omit<WalletAuthTelemetryPayload, "occurredAt" | "service"> &
+  Partial<Pick<WalletAuthTelemetryPayload, "occurredAt">>;
+
+type WalletAuthTelemetrySink = (event: WalletAuthTelemetryPayload) => void;
+
+const defaultSink: WalletAuthTelemetrySink = (event) => {
+  console.info("[wallet-auth-telemetry]", JSON.stringify(event));
+};
+
+let sink: WalletAuthTelemetrySink = defaultSink;
+
+export function setWalletAuthTelemetrySink(next?: WalletAuthTelemetrySink): void {
+  sink = next ?? defaultSink;
+}
+
+export function emitWalletAuthTelemetry(event: ApiWalletAuthTelemetryInput): void {
+  sink({
+    service: "api",
+    occurredAt: new Date().toISOString(),
+    ...event,
+  });
+}

--- a/apps/api/tests/wallet-auth-telemetry-424.test.ts
+++ b/apps/api/tests/wallet-auth-telemetry-424.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { WALLET_AUTH_TELEMETRY_EVENTS, type WalletAuthTelemetryPayload } from "@chordially/types";
+
+import { createApp } from "../src/app.js";
+import { registerUser, resetAuthStore } from "../src/auth-store.js";
+import { resetRateLimitStore } from "../src/rate-limiter.js";
+import { setWalletAuthTelemetrySink } from "../src/telemetry.js";
+
+function collectTelemetry() {
+  const events: WalletAuthTelemetryPayload[] = [];
+  setWalletAuthTelemetrySink((event) => events.push(event));
+  return events;
+}
+
+function resetTelemetry() {
+  setWalletAuthTelemetrySink();
+}
+
+test("issue #424: login success emits sanitized wallet auth telemetry", async () => {
+  resetAuthStore();
+  resetRateLimitStore();
+  const events = collectTelemetry();
+  registerUser({ email: "wallet@example.com", password: "Password1!", displayName: "Wallet" });
+
+  const { default: supertest } = await import("supertest");
+  const res = await supertest(createApp())
+    .post("/api/v1/auth/login")
+    .set("User-Agent", "SensitiveAgent/1.0")
+    .send({ email: "wallet@example.com", password: "Password1!", origin: "web" });
+
+  assert.equal(res.status, 200);
+  assert.equal(events.length, 1);
+  assert.deepEqual(
+    {
+      event: events[0]?.event,
+      outcome: events[0]?.outcome,
+      service: events[0]?.service,
+      boundary: events[0]?.boundary,
+      subjectId: events[0]?.subjectId,
+    },
+    {
+      event: WALLET_AUTH_TELEMETRY_EVENTS.walletLinkSucceeded,
+      outcome: "success",
+      service: "api",
+      boundary: "api.auth.login",
+      subjectId: "user_1",
+    },
+  );
+
+  const serialized = JSON.stringify(events[0]);
+  assert.equal(serialized.includes("wallet@example.com"), false);
+  assert.equal(serialized.includes("Password1!"), false);
+  assert.equal(serialized.includes(res.body.session.token), false);
+  assert.equal(serialized.includes("SensitiveAgent"), false);
+  resetTelemetry();
+});
+
+test("issue #424: login failure emits sanitized failure telemetry", async () => {
+  resetAuthStore();
+  resetRateLimitStore();
+  const events = collectTelemetry();
+  registerUser({ email: "wallet@example.com", password: "Password1!", displayName: "Wallet" });
+
+  const { default: supertest } = await import("supertest");
+  const res = await supertest(createApp())
+    .post("/api/v1/auth/login")
+    .send({ email: "wallet@example.com", password: "WrongPass1!" });
+
+  assert.equal(res.status, 401);
+  assert.equal(events.length, 1);
+  assert.equal(events[0]?.event, WALLET_AUTH_TELEMETRY_EVENTS.walletAuthFailed);
+  assert.equal(events[0]?.boundary, "api.auth.login");
+  assert.equal(events[0]?.reason, "INVALID_CREDENTIALS");
+
+  const serialized = JSON.stringify(events[0]);
+  assert.equal(serialized.includes("wallet@example.com"), false);
+  assert.equal(serialized.includes("WrongPass1!"), false);
+  resetTelemetry();
+});
+
+test("issue #424: logout emits revocation telemetry without token material", async () => {
+  resetAuthStore();
+  resetRateLimitStore();
+  const events = collectTelemetry();
+  registerUser({ email: "wallet@example.com", password: "Password1!", displayName: "Wallet" });
+
+  const { default: supertest } = await import("supertest");
+  const login = await supertest(createApp())
+    .post("/api/v1/auth/login")
+    .send({ email: "wallet@example.com", password: "Password1!" });
+  events.length = 0;
+
+  const res = await supertest(createApp())
+    .post("/api/v1/auth/logout")
+    .send({ token: login.body.session.token });
+
+  assert.equal(res.status, 200);
+  assert.equal(events.length, 1);
+  assert.equal(events[0]?.event, WALLET_AUTH_TELEMETRY_EVENTS.walletLinkRevoked);
+  assert.equal(events[0]?.boundary, "api.auth.logout");
+  assert.equal(events[0]?.sessionsRevoked, 1);
+  assert.equal(JSON.stringify(events[0]).includes(login.body.session.token), false);
+  resetTelemetry();
+});

--- a/apps/stellar-service/package.json
+++ b/apps/stellar-service/package.json
@@ -8,7 +8,7 @@
     "start": "node dist/server.js",
     "lint": "eslint src --ext .ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test"
+    "test": "tsx --test tests/*.test.ts"
   },
   "dependencies": {
     "@chordially/types": "workspace:*",

--- a/apps/stellar-service/src/app.ts
+++ b/apps/stellar-service/src/app.ts
@@ -1,12 +1,14 @@
-import express from "express";
+import express, { type Express } from "express";
+import { WALLET_AUTH_TELEMETRY_EVENTS } from "@chordially/types";
 import { Networks } from "stellar-sdk";
 
 import { env } from "./env.js";
+import { emitWalletAuthTelemetry } from "./telemetry.js";
 
 const networkPassphrase =
   env.STELLAR_NETWORK === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
 
-export function createApp() {
+export function createApp(): Express {
   const app = express();
 
   app.get("/health", (_request, response) => {
@@ -26,6 +28,12 @@ export function createApp() {
   });
 
   app.get("/api/v1/stellar/starter-intent", (_request, response) => {
+    emitWalletAuthTelemetry({
+      event: WALLET_AUTH_TELEMETRY_EVENTS.walletLinkStarted,
+      outcome: "start",
+      boundary: "stellar.starter_intent",
+      network: env.STELLAR_NETWORK,
+    });
     response.json({
       asset: "USDC",
       useCase: "hackathon-mvp",

--- a/apps/stellar-service/src/telemetry.ts
+++ b/apps/stellar-service/src/telemetry.ts
@@ -1,0 +1,25 @@
+import type { WalletAuthTelemetryPayload } from "@chordially/types";
+
+type StellarWalletAuthTelemetryInput =
+  Omit<WalletAuthTelemetryPayload, "occurredAt" | "service"> &
+  Partial<Pick<WalletAuthTelemetryPayload, "occurredAt">>;
+
+type WalletAuthTelemetrySink = (event: WalletAuthTelemetryPayload) => void;
+
+const defaultSink: WalletAuthTelemetrySink = (event) => {
+  console.info("[wallet-auth-telemetry]", JSON.stringify(event));
+};
+
+let sink: WalletAuthTelemetrySink = defaultSink;
+
+export function setWalletAuthTelemetrySink(next?: WalletAuthTelemetrySink): void {
+  sink = next ?? defaultSink;
+}
+
+export function emitWalletAuthTelemetry(event: StellarWalletAuthTelemetryInput): void {
+  sink({
+    service: "stellar-service",
+    occurredAt: new Date().toISOString(),
+    ...event,
+  });
+}

--- a/apps/stellar-service/tests/wallet-auth-telemetry-424.test.ts
+++ b/apps/stellar-service/tests/wallet-auth-telemetry-424.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { type AddressInfo } from "node:net";
+import test from "node:test";
+
+import { WALLET_AUTH_TELEMETRY_EVENTS, type WalletAuthTelemetryPayload } from "@chordially/types";
+
+import { createApp } from "../src/app.js";
+import { setWalletAuthTelemetrySink } from "../src/telemetry.js";
+
+test("issue #424: starter intent emits wallet-link start telemetry", async () => {
+  const events: WalletAuthTelemetryPayload[] = [];
+  setWalletAuthTelemetrySink((event) => events.push(event));
+
+  const app = createApp();
+  const server = app.listen(0);
+
+  try {
+    await new Promise<void>((resolve) => server.once("listening", resolve));
+    const { port } = server.address() as AddressInfo;
+    const res = await fetch(`http://127.0.0.1:${port}/api/v1/stellar/starter-intent`);
+    assert.equal(res.status, 200);
+    await res.json();
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+    setWalletAuthTelemetrySink();
+  }
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0]?.event, WALLET_AUTH_TELEMETRY_EVENTS.walletLinkStarted);
+  assert.equal(events[0]?.outcome, "start");
+  assert.equal(events[0]?.service, "stellar-service");
+  assert.equal(events[0]?.boundary, "stellar.starter_intent");
+  assert.equal(events[0]?.network, "testnet");
+});

--- a/apps/stellar-service/tsconfig.json
+++ b/apps/stellar-service/tsconfig.json
@@ -4,5 +4,5 @@
     "outDir": "dist",
     "rootDir": "."
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -41,3 +41,11 @@ export type Milestone = {
 };
 
 export type { AuthErrorCode } from "./auth-contracts.js";
+export {
+  WALLET_AUTH_TELEMETRY_EVENTS,
+  type WalletAuthTelemetryBoundary,
+  type WalletAuthTelemetryEventName,
+  type WalletAuthTelemetryOutcome,
+  type WalletAuthTelemetryPayload,
+  type WalletAuthTelemetryService,
+} from "./telemetry.js";

--- a/packages/types/src/telemetry.ts
+++ b/packages/types/src/telemetry.ts
@@ -1,0 +1,40 @@
+export const WALLET_AUTH_TELEMETRY_EVENTS = {
+  walletLinkStarted: "wallet_link.started",
+  walletLinkSucceeded: "wallet_link.succeeded",
+  walletAuthFailed: "wallet_auth.failed",
+  walletLinkRevoked: "wallet_link.revoked",
+} as const;
+
+export type WalletAuthTelemetryEventName =
+  (typeof WALLET_AUTH_TELEMETRY_EVENTS)[keyof typeof WALLET_AUTH_TELEMETRY_EVENTS];
+
+export type WalletAuthTelemetryOutcome =
+  | "start"
+  | "success"
+  | "failure"
+  | "revocation";
+
+export type WalletAuthTelemetryBoundary =
+  | "api.auth.login"
+  | "api.auth.logout"
+  | "api.auth.logout_all"
+  | "stellar.starter_intent";
+
+export type WalletAuthTelemetryService = "api" | "stellar-service";
+
+export type WalletAuthTelemetryPayload = {
+  event: WalletAuthTelemetryEventName;
+  outcome: WalletAuthTelemetryOutcome;
+  service: WalletAuthTelemetryService;
+  boundary: WalletAuthTelemetryBoundary;
+  occurredAt: string;
+  /**
+   * Internal stable identifier only. Do not populate this with email,
+   * wallet addresses, access tokens, refresh tokens, signatures, IPs, or
+   * user-agent strings.
+   */
+  subjectId?: string;
+  network?: "testnet" | "mainnet";
+  reason?: string;
+  sessionsRevoked?: number;
+};


### PR DESCRIPTION
## Summary
- Define shared wallet-link and wallet-auth telemetry event names, outcomes, boundaries, and payload shape in `@chordially/types`
- Emit sanitized server-side events from API login/logout boundaries and Stellar starter-intent boundary
- Add focused tests proving success, failure, revocation, and starter-intent events exclude emails, passwords, tokens, user-agent strings, and signing artifacts

## Testing
- `pnpm --filter @chordially/api exec tsx --test tests/wallet-auth-telemetry-424.test.ts`
- `pnpm --filter @chordially/stellar-service exec tsx --test tests/wallet-auth-telemetry-424.test.ts`
- `pnpm --filter @chordially/types typecheck`
- `pnpm --filter @chordially/api typecheck`
- `pnpm --filter @chordially/stellar-service typecheck`
- `pnpm --filter @chordially/api lint` (passes with existing warnings)
- `pnpm --filter @chordially/stellar-service lint`
- `pnpm --filter @chordially/types lint`
- `git diff --check`

Note: full `pnpm --filter @chordially/api test` currently has 4 pre-existing lockout expectation failures in `auth-330-lockout.test.ts` around `ACCOUNT_LOCKED` / `LOGIN_FAILED`; the new telemetry tests pass.

Fixes #424