### PR TITLE
feat(web): prevent duplicate auth submissions

### DIFF
--- a/apps/web/app/auth/reset-password/confirm/page.tsx
+++ b/apps/web/app/auth/reset-password/confirm/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type FormEvent } from "react";
+import { useRef, useState, type FormEvent } from "react";
 
 type Phase = "idle" | "loading" | "success" | "expired" | "reused" | "error";
 
@@ -17,6 +17,7 @@ export default function ResetConfirmPage({
 }) {
   const [phase, setPhase] = useState<Phase>("idle");
   const [mismatch, setMismatch] = useState(false);
+  const submissionLock = useRef(false);
   const token = searchParams.token ?? "";
 
   if (!token) {
@@ -51,12 +52,14 @@ export default function ResetConfirmPage({
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
+    if (submissionLock.current || phase === "loading") return;
     const data = new FormData(e.currentTarget);
     const password = data.get("password") as string;
     const confirm = data.get("confirm") as string;
 
     if (password !== confirm) { setMismatch(true); return; }
     setMismatch(false);
+    submissionLock.current = true;
     setPhase("loading");
 
     try {
@@ -71,6 +74,8 @@ export default function ResetConfirmPage({
       else setPhase("error");
     } catch {
       setPhase("error");
+    } finally {
+      submissionLock.current = false;
     }
   }
 

--- a/apps/web/app/auth/reset-password/page.tsx
+++ b/apps/web/app/auth/reset-password/page.tsx
@@ -1,14 +1,17 @@
 "use client";
 
-import { useState, type FormEvent } from "react";
+import { useRef, useState, type FormEvent } from "react";
 
 type Phase = "idle" | "loading" | "sent" | "error";
 
 export default function ResetRequestPage() {
   const [phase, setPhase] = useState<Phase>("idle");
+  const submissionLock = useRef(false);
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
+    if (submissionLock.current || phase === "loading") return;
+    submissionLock.current = true;
     setPhase("loading");
     const email = new FormData(e.currentTarget).get("email") as string;
 
@@ -21,6 +24,8 @@ export default function ResetRequestPage() {
       setPhase("sent");
     } catch {
       setPhase("error");
+    } finally {
+      submissionLock.current = false;
     }
   }
 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "../../packages/config/tsconfig.base.json",
   "compilerOptions": {
     "jsx": "preserve",
-    "lib": ["dom", "dom.iterable", "es2020"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es2020"
+    ],
     "allowJs": false,
     "incremental": true,
     "isolatedModules": true,
@@ -10,8 +14,16 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "noEmit": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
Closes #351

Closes #350
Closes #352
Closes #353

## Summary
- Prevents duplicate submissions during in-flight auth requests using an immediate submission lock
- Keeps optimistic/pending UX lightweight without wiping user input on failure

## Testing
- pnpm --filter @chordially/web lint
- pnpm --filter @chordially/web typecheck
- pnpm --filter @chordially/web build