### PR TITLE
Auth Lexicon: contributor states, fixtures, and smoke baseline commands

### DIFF
--- a/docs/auth-contributor-glossary.md
+++ b/docs/auth-contributor-glossary.md
@@ -1,0 +1,8 @@
+# Auth Contributor Glossary
+
+- `signed_out`: no active auth session.
+- `email_unverified`: account exists but verification step is incomplete.
+- `signed_in`: active session and resolved role.
+- `forbidden`: authenticated user lacks permission for requested action.
+- `session_restore`: client bootstrap step that rehydrates prior auth state.
+- `challenge_boundary`: optional future checkpoint (biometric/MFA), not mandatory in starter.

--- a/docs/auth-smoke-commands.md
+++ b/docs/auth-smoke-commands.md
@@ -1,0 +1,12 @@
+# Auth Smoke Commands
+
+Run these before publishing auth-related issues or PRs:
+
+1. `pnpm --filter @chordially/api test`
+2. `pnpm --filter @chordially/web test`
+3. `pnpm --filter @chordially/mobile test`
+4. `pnpm repo:health`
+
+Expected baseline:
+- No failing auth tests.
+- No missing auth env warnings in local startup logs.

--- a/packages/types/src/auth-fixtures.ts
+++ b/packages/types/src/auth-fixtures.ts
@@ -1,0 +1,13 @@
+export type ContributorAuthState =
+  | { status: "signed_out" }
+  | { status: "email_unverified"; email: string }
+  | { status: "signed_in"; email: string; role: "listener" | "artist" | "admin" }
+  | { status: "forbidden"; reason: "insufficient_permission" | "suspended" };
+
+export const authFixtures: Record<string, ContributorAuthState> = {
+  signedOut: { status: "signed_out" },
+  unverified: { status: "email_unverified", email: "new-user@chordially.test" },
+  listener: { status: "signed_in", email: "listener@chordially.test", role: "listener" },
+  artist: { status: "signed_in", email: "artist@chordially.test", role: "artist" },
+  forbidden: { status: "forbidden", reason: "insufficient_permission" },
+};

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -52,3 +52,17 @@ export interface ApiErrorEnvelope {
 }
 
 export const API_V1_PREFIX = "/api/v1";
+
+export type ContributorAuthState =
+  | { status: "signed_out" }
+  | { status: "email_unverified"; email: string }
+  | { status: "signed_in"; email: string; role: "listener" | "artist" | "admin" }
+  | { status: "forbidden"; reason: "insufficient_permission" | "suspended" };
+
+export const authFixtures: Record<string, ContributorAuthState> = {
+  signedOut: { status: "signed_out" },
+  unverified: { status: "email_unverified", email: "new-user@chordially.test" },
+  listener: { status: "signed_in", email: "listener@chordially.test", role: "listener" },
+  artist: { status: "signed_in", email: "artist@chordially.test", role: "artist" },
+  forbidden: { status: "forbidden", reason: "insufficient_permission" },
+};

--- a/tooling/smoke.ts
+++ b/tooling/smoke.ts
@@ -1,1 +1,8 @@
 export const toolingSmoke = "chordially";
+
+export const authSmokeCommands = [
+  "pnpm --filter @chordially/api test",
+  "pnpm --filter @chordially/web test",
+  "pnpm --filter @chordially/mobile test",
+  "pnpm repo:health",
+];


### PR DESCRIPTION
Summary: adds minimal shared auth contributor assets across docs/types/tooling.

What changed:
- Added monorepo auth naming glossary.
- Added explicit contributor account state model + shared fixture data.
- Added workspace-level auth smoke commands documentation and tooling export.

Closes #390
Closes #391
Closes #392
Closes #393