### PR TITLE
feat(web): auth status component in public shell

### DIFF
--- a/apps/web/app/_components/auth-status.tsx
+++ b/apps/web/app/_components/auth-status.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { authClient } from "../../lib/auth-client";
+import { readStoredSession, subscribeToStoredSessionChanges, writeStoredSession } from "../../lib/session-storage";
+
+type StatusState =
+  | { kind: "signed-out" }
+  | { kind: "loading" }
+  | { kind: "restricted"; message: string }
+  | { kind: "signed-in"; displayName: string; role: string };
+
+const restrictedMessages: Record<string, string> = {
+  FORBIDDEN: "Signed in, but missing permission for this experience.",
+  ACCOUNT_DISABLED: "This account is disabled.",
+  ACCOUNT_BANNED: "This account is banned.",
+};
+
+export function AuthStatus() {
+  const [state, setState] = useState<StatusState>({ kind: "loading" });
+  const session = useMemo(() => readStoredSession(), []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function refresh() {
+      const current = readStoredSession();
+      if (!current?.token) {
+        if (!cancelled) setState({ kind: "signed-out" });
+        return;
+      }
+
+      if (!cancelled) setState({ kind: "loading" });
+      const result = await authClient.me(current.token);
+      if (cancelled) return;
+
+      if (result.ok) {
+        setState({
+          kind: "signed-in",
+          displayName: result.data.user.displayName,
+          role: result.data.user.role,
+        });
+        return;
+      }
+
+      const friendly = restrictedMessages[result.error.error];
+      if (friendly) {
+        setState({ kind: "restricted", message: friendly });
+        return;
+      }
+
+      // Treat invalid/expired sessions as signed out, but preserve the ability to sign in again.
+      writeStoredSession(null);
+      setState({ kind: "signed-out" });
+    }
+
+    void refresh();
+    const unsubscribe = subscribeToStoredSessionChanges(() => void refresh());
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [session]);
+
+  const accent =
+    state.kind === "signed-in"
+      ? "var(--accent-strong)"
+      : state.kind === "restricted"
+        ? "var(--accent)"
+        : "var(--muted)";
+
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 10 }}>
+      <span style={{ fontSize: "0.95rem", color: accent }}>
+        {state.kind === "loading" && "Checking session…"}
+        {state.kind === "signed-out" && "Signed out"}
+        {state.kind === "restricted" && state.message}
+        {state.kind === "signed-in" && `Signed in as ${state.displayName} (${state.role})`}
+      </span>
+
+      {state.kind === "signed-in" ? (
+        <button
+          type="button"
+          className="secondary-link"
+          style={{ cursor: "pointer", border: "1px solid var(--border)", background: "transparent" }}
+          onClick={() => writeStoredSession(null)}
+        >
+          Sign out
+        </button>
+      ) : (
+        <a className="secondary-link" href="/auth">
+          Sign in
+        </a>
+      )}
+    </div>
+  );
+}
+

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
+import { AuthStatus } from "./_components/auth-status";
+
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -11,7 +13,17 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <header style={{ padding: "22px 20px 0", maxWidth: 1040, margin: "0 auto" }}>
+          <nav style={{ display: "flex", flexWrap: "wrap", alignItems: "center", justifyContent: "space-between", gap: 16 }}>
+            <a href="/" className="eyebrow" style={{ margin: 0 }}>
+              Chordially starter
+            </a>
+            <AuthStatus />
+          </nav>
+        </header>
+        {children}
+      </body>
     </html>
   );
 }

--- a/apps/web/lib/session-storage.ts
+++ b/apps/web/lib/session-storage.ts
@@ -1,0 +1,50 @@
+export type StoredAuthSession = {
+  token: string;
+  refreshToken?: string;
+};
+
+const SESSION_KEY = "chordially.session";
+const EVENT_NAME = "chordially:session";
+
+function isStoredSession(value: unknown): value is StoredAuthSession {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return typeof record["token"] === "string";
+}
+
+export function readStoredSession(): StoredAuthSession | null {
+  if (typeof window === "undefined") return null;
+  const raw = window.localStorage.getItem(SESSION_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return isStoredSession(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredSession(session: StoredAuthSession | null): void {
+  if (typeof window === "undefined") return;
+  if (!session) window.localStorage.removeItem(SESSION_KEY);
+  else window.localStorage.setItem(SESSION_KEY, JSON.stringify(session));
+
+  window.dispatchEvent(new Event(EVENT_NAME));
+}
+
+export function subscribeToStoredSessionChanges(handler: () => void): () => void {
+  if (typeof window === "undefined") return () => undefined;
+  const onStorage = (event: StorageEvent) => {
+    if (event.key === SESSION_KEY) handler();
+  };
+  const onCustom = () => handler();
+
+  window.addEventListener("storage", onStorage);
+  window.addEventListener(EVENT_NAME, onCustom);
+
+  return () => {
+    window.removeEventListener("storage", onStorage);
+    window.removeEventListener(EVENT_NAME, onCustom);
+  };
+}
+

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "../../packages/config/tsconfig.base.json",
   "compilerOptions": {
     "jsx": "preserve",
-    "lib": ["dom", "dom.iterable", "es2020"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es2020"
+    ],
     "allowJs": false,
     "incremental": true,
     "isolatedModules": true,
@@ -10,8 +14,16 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "noEmit": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
Closes #358

Closes #359, 
Closes #360, 
Closes #361

## Summary
- Adds a compact `AuthStatus` surface to the shared web layout
- Uses real session data (`/api/v1/auth/me`) when a stored token is present
- Reacts to sign-in/sign-out transitions via localStorage + a custom browser event

## Testing
- pnpm --filter @chordially/web lint
- pnpm --filter @chordially/web typecheck
- pnpm --filter @chordially/web build