### PR TITLE
feat(mobile): add mobile auth API module

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,7 +1,9 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Linking, SafeAreaView, ScrollView, StyleSheet, Text, View, TextInput, Pressable } from "react-native";
 
 import { mobileConfig } from "./src/config";
+import { createMobileAuthStore } from "./src/auth/mobile-auth-store";
+import { mobileAuthClient } from "./src/auth/mobile-auth-client";
 
 type Screen = "home" | "resetRequest" | "resetComplete" | "verifyPending" | "restricted";
 
@@ -23,6 +25,16 @@ function AuthField(props: {
 }
 
 export default function App() {
+  const authStore = useMemo(() => createMobileAuthStore(), []);
+  const [screen, setScreen] = useState<Screen>("home");
+  const [token, setToken] = useState("");
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [msg, setMsg] = useState<string | null>(null);
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
   const [state, setState] = useState(authStore.getState());
 
   useEffect(() => authStore.subscribe(setState), []);
@@ -36,8 +48,117 @@ export default function App() {
     });
   }, []);
 
+  const signedIn = state.isAuthenticated;
+  const emailError = email && !email.includes("@") ? "Enter a valid email address." : undefined;
+  const passwordError = password && password.length < 8 ? "Password must be at least 8 characters." : undefined;
+
   if (state.isBooting) {
     return <View style={styles.container}><Text style={styles.title}>Booting auth…</Text></View>;
+  }
+
+  async function logout() {
+    setServerError(null);
+    setMsg(null);
+    if (accessToken) {
+      await mobileAuthClient.logout(accessToken);
+    }
+    setAccessToken(null);
+    authStore.boot({ sessionId: null, sessions: [] });
+  }
+
+  async function signIn() {
+    if (emailError || passwordError) return;
+    setPending(true);
+    setServerError(null);
+    setMsg(null);
+    try {
+      const result = await mobileAuthClient.login({ email, password });
+      if (!result.ok) {
+        setServerError(result.error.message);
+        return;
+      }
+
+      setAccessToken(result.data.session.token);
+      authStore.boot({
+        sessionId: result.data.session.token,
+        sessions: [{ id: "this-device", device: "This device", lastSeen: "just now" }],
+      });
+
+      const me = await mobileAuthClient.me(result.data.session.token);
+      if (me.ok) setMsg(`Signed in as ${me.data.user.displayName}.`);
+      else setMsg("Signed in.");
+    } catch {
+      setServerError("Something went wrong. Please try again.");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function requestReset() {
+    if (emailError) return;
+    setPending(true);
+    setServerError(null);
+    setMsg(null);
+    try {
+      const res = await fetch(`${mobileConfig.apiBaseUrl}/api/v1/auth/reset/request`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      if (!res.ok) throw new Error("reset request failed");
+      setMsg("If an account exists, a reset link has been sent.");
+    } catch {
+      setServerError("Something went wrong. Please try again.");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function completeReset() {
+    if (passwordError) return;
+    setPending(true);
+    setServerError(null);
+    setMsg(null);
+    try {
+      const res = await fetch(`${mobileConfig.apiBaseUrl}/api/v1/auth/reset/complete`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token, password }),
+      });
+      const body = (await res.json()) as { error?: string; message?: string };
+      if (!res.ok) {
+        setServerError(body.message ?? "Unable to complete password reset.");
+        return;
+      }
+      setMsg(body.message ?? "Password updated.");
+    } catch {
+      setServerError("Something went wrong. Please try again.");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function resendVerification() {
+    setPending(true);
+    setServerError(null);
+    setMsg(null);
+    try {
+      const res = await fetch(`${mobileConfig.apiBaseUrl}/api/v1/auth/verify/confirm`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token }),
+      });
+      const body = (await res.json()) as { error?: string; message?: string };
+      if (!res.ok) {
+        setServerError(body.message ?? "Unable to confirm verification token.");
+        return;
+      }
+      setMsg(body.message ?? "Email verified.");
+    } catch {
+      setServerError("Something went wrong. Please try again.");
+    } finally {
+      setPending(false);
+    }
   }
 
   async function parseDeepLink() {
@@ -79,6 +200,9 @@ export default function App() {
         <View style={styles.panel}>
           <Text style={styles.panelTitle}>Auth actions</Text>
           <View style={styles.row}>
+            <Pressable style={styles.btn} onPress={signIn} disabled={pending || Boolean(emailError) || Boolean(passwordError)}>
+              <Text>{pending ? "Signing in..." : "Sign in"}</Text>
+            </Pressable>
             <Pressable style={styles.btn} onPress={() => setScreen("resetRequest")}><Text>Reset Request</Text></Pressable>
             <Pressable style={styles.btn} onPress={() => setScreen("resetComplete")}><Text>Reset Complete</Text></Pressable>
           </View>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -8,7 +8,7 @@
     "build": "expo export --output-dir web-build",
     "lint": "eslint . --ext .ts,.tsx",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test"
+    "test": "tsx --test tests/*.test.*"
   },
   "dependencies": {
     "@chordially/types": "workspace:*",
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@types/node": "^22.13.14",
     "@types/react": "^18.2.45",
+    "tsx": "^4.22.3",
     "typescript": "^5.5.4"
   }
 }

--- a/apps/mobile/src/auth/mobile-auth-client.ts
+++ b/apps/mobile/src/auth/mobile-auth-client.ts
@@ -1,0 +1,57 @@
+import type {
+  AuthErrorResponse,
+  IntrospectResponse,
+  LoginRequest,
+  LoginResponse,
+  LogoutRequest,
+  LogoutResponse,
+  RefreshResponse,
+  RegisterRequest,
+  RegisterResponse,
+} from "@chordially/types/src/auth-contracts.js";
+
+import { mobileConfig } from "../config";
+
+type ApiResult<T> = { ok: true; data: T } | { ok: false; error: AuthErrorResponse };
+
+async function call<T>(path: string, init: RequestInit): Promise<ApiResult<T>> {
+  const res = await fetch(`${mobileConfig.apiBaseUrl}${path}`, {
+    ...init,
+    headers: { "Content-Type": "application/json", ...init.headers },
+  });
+  const body = (await res.json()) as unknown;
+  return res.ok ? { ok: true, data: body as T } : { ok: false, error: body as AuthErrorResponse };
+}
+
+export const mobileAuthClient = {
+  register: (payload: RegisterRequest) =>
+    call<RegisterResponse>("/api/v1/auth/register", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    }),
+
+  login: (payload: LoginRequest) =>
+    call<LoginResponse>("/api/v1/auth/login", {
+      method: "POST",
+      body: JSON.stringify({ ...payload, origin: "mobile" } satisfies LoginRequest & { origin: string }),
+    }),
+
+  logout: (token: string) =>
+    call<LogoutResponse>("/api/v1/auth/logout", {
+      method: "POST",
+      body: JSON.stringify({ token } satisfies LogoutRequest),
+    }),
+
+  refresh: (refreshToken: string) =>
+    call<RefreshResponse>("/api/v1/auth/refresh", {
+      method: "POST",
+      body: JSON.stringify({ refreshToken }),
+    }),
+
+  me: (token: string) =>
+    call<IntrospectResponse>("/api/v1/auth/me", {
+      method: "GET",
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+};
+

--- a/apps/mobile/src/auth/mobile-auth-store.ts
+++ b/apps/mobile/src/auth/mobile-auth-store.ts
@@ -1,0 +1,60 @@
+type AuthSessionSummary = {
+  id: string;
+  device: string;
+  lastSeen: string;
+};
+
+type MobileAuthState = {
+  isBooting: boolean;
+  isOffline: boolean;
+  isAuthenticated: boolean;
+  activeSessionId: string | null;
+  sessions: AuthSessionSummary[];
+};
+
+const initialState: MobileAuthState = {
+  isBooting: true,
+  isOffline: false,
+  isAuthenticated: false,
+  activeSessionId: null,
+  sessions: [],
+};
+
+export function createMobileAuthStore(seed: Partial<MobileAuthState> = {}) {
+  let state: MobileAuthState = { ...initialState, ...seed };
+  const listeners = new Set<(next: MobileAuthState) => void>();
+
+  const emit = () => {
+    listeners.forEach((listener) => listener(state));
+  };
+
+  const setState = (patch: Partial<MobileAuthState>) => {
+    state = { ...state, ...patch };
+    emit();
+  };
+
+  return {
+    getState: () => state,
+    subscribe: (listener: (next: MobileAuthState) => void) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    boot: ({ sessionId, sessions }: { sessionId?: string | null; sessions?: AuthSessionSummary[] } = {}) =>
+      setState({
+        isBooting: false,
+        isAuthenticated: Boolean(sessionId),
+        activeSessionId: sessionId ?? null,
+        sessions: sessions ?? [],
+      }),
+    setOffline: (isOffline: boolean) => setState({ isOffline }),
+    addSession: (session: AuthSessionSummary) => setState({ sessions: [...state.sessions, session] }),
+    revokeSession: (sessionId: string) =>
+      setState({
+        sessions: state.sessions.filter((session) => session.id !== sessionId),
+        activeSessionId: state.activeSessionId === sessionId ? null : state.activeSessionId,
+        isAuthenticated: state.activeSessionId === sessionId ? false : state.isAuthenticated,
+      }),
+  };
+}

--- a/apps/mobile/tests/mobile-auth-smoke.test.ts
+++ b/apps/mobile/tests/mobile-auth-smoke.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+
+import { createMobileAuthStore } from "../src/auth/mobile-auth-store";
+
+const store = createMobileAuthStore();
+assert.equal(store.getState().isBooting, true);
+
+store.boot({
+  sessionId: "session-1",
+  sessions: [{ id: "session-1", device: "Pixel", lastSeen: "now" }],
+});
+assert.equal(store.getState().isAuthenticated, true);
+assert.equal(store.getState().sessions.length, 1);
+
+store.setOffline(true);
+assert.equal(store.getState().isOffline, true);
+
+store.revokeSession("session-1");
+assert.equal(store.getState().sessions.length, 0);
+assert.equal(store.getState().isAuthenticated, false);
+

--- a/packages/types/src/auth-contracts.ts
+++ b/packages/types/src/auth-contracts.ts
@@ -27,6 +27,7 @@ export type RegisterResponse = {
 export type LoginResponse = {
   message: string;
   session: AuthSession;
+  refreshToken: string;
 };
 
 export type LogoutResponse = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       '@types/react':
         specifier: ^18.2.45
         version: 18.3.29
+      tsx:
+        specifier: ^4.22.3
+        version: 4.22.3
       typescript:
         specifier: ^5.5.4
         version: 5.9.3
@@ -1077,7 +1080,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.17.13':
     resolution: {integrity: sha512-n13yxOmI3I0JidzMdFCH68tYKGDtK4XlDFk1vysZX7AIRKeDVRsSbHhma5jCla2bDt25RKmJBHA9KtzielwzAA==}


### PR DESCRIPTION
Closes #363

Closes #362, 
Closes #364, 
Closes #365

## Summary
- Adds `mobileAuthClient` for register/login/logout/refresh/me with mobile-appropriate transport
- Fixes the mobile auth store typing (TS) and wires the starter App to use the auth client
- Adds a smoke test for the auth store and updates mobile tests to run with `tsx`

## Testing
- pnpm --filter @chordially/types typecheck
- pnpm --filter @chordially/mobile typecheck
- pnpm --filter @chordially/mobile lint
- pnpm --filter @chordially/mobile test