### PR TITLE
Add CreatorProfile model and creators module

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -8,9 +8,25 @@ datasource db {
 }
 
 model User {
-  id           String   @id @default(cuid())
-  email        String   @unique
-  passwordHash String
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  id             String          @id @default(cuid())
+  email          String          @unique
+  passwordHash   String
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
+  creatorProfile CreatorProfile?
+}
+
+model CreatorProfile {
+  id          String   @id @default(cuid())
+  userId      String   @unique
+  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  displayName String
+  slug        String   @unique
+  bio         String?
+  avatarUrl   String?
+  genre       String?
+  location    String?
+  isVerified  Boolean  @default(false)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 }

--- a/apps/api/src/modules/creators/index.ts
+++ b/apps/api/src/modules/creators/index.ts
@@ -1,0 +1,9 @@
+export { creatorRepository } from "./repositories/creator.repository.js"
+export { creatorService } from "./services/creator.service.js"
+export {
+  toCreatorResponse,
+  type CreateCreatorInput,
+  type CreatorProfile,
+  type CreatorResponse,
+  type UpdateCreatorInput,
+} from "./types/creator.types.js"

--- a/apps/api/src/modules/creators/repositories/creator.repository.ts
+++ b/apps/api/src/modules/creators/repositories/creator.repository.ts
@@ -1,0 +1,40 @@
+import { prisma } from "../../../shared/database/prisma.js"
+import type {
+  CreateCreatorInput,
+  CreatorProfile,
+  UpdateCreatorInput,
+} from "../types/creator.types.js"
+
+export const creatorRepository = {
+  findById(id: string): Promise<CreatorProfile | null> {
+    return prisma.creatorProfile.findUnique({ where: { id } })
+  },
+
+  findBySlug(slug: string): Promise<CreatorProfile | null> {
+    return prisma.creatorProfile.findUnique({ where: { slug } })
+  },
+
+  findByUserId(userId: string): Promise<CreatorProfile | null> {
+    return prisma.creatorProfile.findUnique({ where: { userId } })
+  },
+
+  create(input: CreateCreatorInput & { slug: string }): Promise<CreatorProfile> {
+    return prisma.creatorProfile.create({
+      data: {
+        userId: input.userId,
+        displayName: input.displayName,
+        slug: input.slug,
+        bio: input.bio,
+        genre: input.genre,
+        location: input.location,
+      },
+    })
+  },
+
+  update(id: string, input: UpdateCreatorInput): Promise<CreatorProfile> {
+    return prisma.creatorProfile.update({
+      where: { id },
+      data: input,
+    })
+  },
+}

--- a/apps/api/src/modules/creators/services/creator.service.ts
+++ b/apps/api/src/modules/creators/services/creator.service.ts
@@ -1,0 +1,49 @@
+import { AppError } from "../../../shared/errors/app-error.js"
+import { toSlug } from "../../../shared/utils/slug.js"
+import { creatorRepository } from "../repositories/creator.repository.js"
+import type {
+  CreateCreatorInput,
+  CreatorProfile,
+  UpdateCreatorInput,
+} from "../types/creator.types.js"
+
+export const creatorService = {
+  findById(id: string): Promise<CreatorProfile | null> {
+    return creatorRepository.findById(id)
+  },
+
+  findBySlug(slug: string): Promise<CreatorProfile | null> {
+    return creatorRepository.findBySlug(slug)
+  },
+
+  findByUserId(userId: string): Promise<CreatorProfile | null> {
+    return creatorRepository.findByUserId(userId)
+  },
+
+  async createCreatorProfile(input: CreateCreatorInput): Promise<CreatorProfile> {
+    const existing = await creatorRepository.findByUserId(input.userId)
+    if (existing) {
+      throw new AppError(
+        409,
+        "CREATOR_PROFILE_EXISTS",
+        "A creator profile already exists for this account"
+      )
+    }
+
+    const slug = toSlug(input.displayName)
+
+    return creatorRepository.create({ ...input, slug })
+  },
+
+  async updateCreatorProfile(
+    id: string,
+    input: UpdateCreatorInput
+  ): Promise<CreatorProfile> {
+    const profile = await creatorRepository.findById(id)
+    if (!profile) {
+      throw new AppError(404, "CREATOR_NOT_FOUND", "Creator profile not found")
+    }
+
+    return creatorRepository.update(id, input)
+  },
+}

--- a/apps/api/src/modules/creators/services/creator.service.ts
+++ b/apps/api/src/modules/creators/services/creator.service.ts
@@ -1,5 +1,5 @@
 import { AppError } from "../../../shared/errors/app-error.js"
-import { toSlug } from "../../../shared/utils/slug.js"
+import { generateUniqueSlug } from "../../../shared/utils/slug.js"
 import { creatorRepository } from "../repositories/creator.repository.js"
 import type {
   CreateCreatorInput,
@@ -30,18 +30,30 @@ export const creatorService = {
       )
     }
 
-    const slug = toSlug(input.displayName)
+    const slug = await generateUniqueSlug(
+      input.displayName,
+      creatorRepository.findBySlug
+    )
 
     return creatorRepository.create({ ...input, slug })
   },
 
   async updateCreatorProfile(
     id: string,
-    input: UpdateCreatorInput
+    input: UpdateCreatorInput,
+    requestingUserId: string
   ): Promise<CreatorProfile> {
     const profile = await creatorRepository.findById(id)
     if (!profile) {
       throw new AppError(404, "CREATOR_NOT_FOUND", "Creator profile not found")
+    }
+
+    if (profile.userId !== requestingUserId) {
+      throw new AppError(
+        403,
+        "FORBIDDEN",
+        "You do not have permission to edit this profile"
+      )
     }
 
     return creatorRepository.update(id, input)

--- a/apps/api/src/modules/creators/tests/creator.service.test.ts
+++ b/apps/api/src/modules/creators/tests/creator.service.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { prisma } from "../../../shared/database/prisma.js"
+import { creatorService } from "../services/creator.service.js"
+
+async function createTestUser(email = "creator@test.com") {
+  return prisma.user.create({
+    data: { email, passwordHash: "irrelevant-hash" },
+  })
+}
+
+describe("creatorService.createCreatorProfile", () => {
+  it("creates a profile and derives the slug from the display name", async () => {
+    const user = await createTestUser()
+
+    const profile = await creatorService.createCreatorProfile({
+      userId: user.id,
+      displayName: "Jordan Rivers",
+      bio: "Indie artist",
+      genre: "Jazz",
+    })
+
+    expect(profile.userId).toBe(user.id)
+    expect(profile.displayName).toBe("Jordan Rivers")
+    expect(profile.slug).toBe("jordan-rivers")
+    expect(profile.bio).toBe("Indie artist")
+    expect(profile.isVerified).toBe(false)
+  })
+
+  it("throws 409 CREATOR_PROFILE_EXISTS when the user already has a profile", async () => {
+    const user = await createTestUser()
+    await creatorService.createCreatorProfile({
+      userId: user.id,
+      displayName: "Jordan Rivers",
+    })
+
+    await expect(
+      creatorService.createCreatorProfile({
+        userId: user.id,
+        displayName: "Jordan Rivers Again",
+      })
+    ).rejects.toMatchObject({ statusCode: 409, code: "CREATOR_PROFILE_EXISTS" })
+  })
+
+  it("strips special characters from the slug", async () => {
+    const user = await createTestUser()
+
+    const profile = await creatorService.createCreatorProfile({
+      userId: user.id,
+      displayName: "DJ Ché & The Ø",
+    })
+
+    expect(profile.slug).toBe("dj-ch-the")
+  })
+})
+
+describe("creatorService.findBySlug", () => {
+  it("returns the profile for a known slug", async () => {
+    const user = await createTestUser()
+    await creatorService.createCreatorProfile({
+      userId: user.id,
+      displayName: "Solar Vibes",
+    })
+
+    const found = await creatorService.findBySlug("solar-vibes")
+    expect(found).not.toBeNull()
+    expect(found?.displayName).toBe("Solar Vibes")
+  })
+
+  it("returns null for an unknown slug", async () => {
+    const result = await creatorService.findBySlug("does-not-exist")
+    expect(result).toBeNull()
+  })
+})
+
+describe("creatorService.updateCreatorProfile", () => {
+  it("updates the fields provided", async () => {
+    const user = await createTestUser()
+    const profile = await creatorService.createCreatorProfile({
+      userId: user.id,
+      displayName: "Original Name",
+    })
+
+    const updated = await creatorService.updateCreatorProfile(profile.id, {
+      bio: "Updated bio",
+      location: "Abuja",
+    })
+
+    expect(updated.bio).toBe("Updated bio")
+    expect(updated.location).toBe("Abuja")
+    expect(updated.displayName).toBe("Original Name")
+  })
+
+  it("throws 404 CREATOR_NOT_FOUND for a non-existent profile id", async () => {
+    await expect(
+      creatorService.updateCreatorProfile("nonexistent-id", { bio: "Hello" })
+    ).rejects.toMatchObject({ statusCode: 404, code: "CREATOR_NOT_FOUND" })
+  })
+})

--- a/apps/api/src/modules/creators/tests/creator.service.test.ts
+++ b/apps/api/src/modules/creators/tests/creator.service.test.ts
@@ -51,6 +51,29 @@ describe("creatorService.createCreatorProfile", () => {
 
     expect(profile.slug).toBe("dj-ch-the")
   })
+
+  it("appends a numeric suffix when the base slug is already taken", async () => {
+    const userA = await createTestUser("a@test.com")
+    const userB = await createTestUser("b@test.com")
+    const userC = await createTestUser("c@test.com")
+
+    const profileA = await creatorService.createCreatorProfile({
+      userId: userA.id,
+      displayName: "Solar Vibes",
+    })
+    const profileB = await creatorService.createCreatorProfile({
+      userId: userB.id,
+      displayName: "Solar Vibes",
+    })
+    const profileC = await creatorService.createCreatorProfile({
+      userId: userC.id,
+      displayName: "Solar Vibes",
+    })
+
+    expect(profileA.slug).toBe("solar-vibes")
+    expect(profileB.slug).toBe("solar-vibes-2")
+    expect(profileC.slug).toBe("solar-vibes-3")
+  })
 })
 
 describe("creatorService.findBySlug", () => {
@@ -73,26 +96,45 @@ describe("creatorService.findBySlug", () => {
 })
 
 describe("creatorService.updateCreatorProfile", () => {
-  it("updates the fields provided", async () => {
+  it("updates the fields provided when called by the owner", async () => {
     const user = await createTestUser()
     const profile = await creatorService.createCreatorProfile({
       userId: user.id,
       displayName: "Original Name",
     })
 
-    const updated = await creatorService.updateCreatorProfile(profile.id, {
-      bio: "Updated bio",
-      location: "Abuja",
-    })
+    const updated = await creatorService.updateCreatorProfile(
+      profile.id,
+      { bio: "Updated bio", location: "Abuja" },
+      user.id
+    )
 
     expect(updated.bio).toBe("Updated bio")
     expect(updated.location).toBe("Abuja")
     expect(updated.displayName).toBe("Original Name")
   })
 
-  it("throws 404 CREATOR_NOT_FOUND for a non-existent profile id", async () => {
+  it("throws 403 FORBIDDEN when a different user attempts to update", async () => {
+    const owner = await createTestUser("owner@test.com")
+    const intruder = await createTestUser("intruder@test.com")
+    const profile = await creatorService.createCreatorProfile({
+      userId: owner.id,
+      displayName: "Owner's Profile",
+    })
+
     await expect(
-      creatorService.updateCreatorProfile("nonexistent-id", { bio: "Hello" })
+      creatorService.updateCreatorProfile(
+        profile.id,
+        { bio: "Malicious edit" },
+        intruder.id
+      )
+    ).rejects.toMatchObject({ statusCode: 403, code: "FORBIDDEN" })
+  })
+
+  it("throws 404 CREATOR_NOT_FOUND for a non-existent profile id", async () => {
+    const user = await createTestUser()
+    await expect(
+      creatorService.updateCreatorProfile("nonexistent-id", { bio: "Hello" }, user.id)
     ).rejects.toMatchObject({ statusCode: 404, code: "CREATOR_NOT_FOUND" })
   })
 })

--- a/apps/api/src/modules/creators/types/creator.types.ts
+++ b/apps/api/src/modules/creators/types/creator.types.ts
@@ -1,0 +1,59 @@
+export interface CreatorProfile {
+  id: string
+  userId: string
+  displayName: string
+  slug: string
+  bio: string | null
+  avatarUrl: string | null
+  genre: string | null
+  location: string | null
+  isVerified: boolean
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface CreateCreatorInput {
+  userId: string
+  displayName: string
+  bio?: string
+  genre?: string
+  location?: string
+}
+
+export interface UpdateCreatorInput {
+  displayName?: string
+  bio?: string | null
+  avatarUrl?: string | null
+  genre?: string
+  location?: string
+}
+
+export interface CreatorResponse {
+  id: string
+  userId: string
+  displayName: string
+  slug: string
+  bio: string | null
+  avatarUrl: string | null
+  genre: string | null
+  location: string | null
+  isVerified: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export function toCreatorResponse(profile: CreatorProfile): CreatorResponse {
+  return {
+    id: profile.id,
+    userId: profile.userId,
+    displayName: profile.displayName,
+    slug: profile.slug,
+    bio: profile.bio,
+    avatarUrl: profile.avatarUrl,
+    genre: profile.genre,
+    location: profile.location,
+    isVerified: profile.isVerified,
+    createdAt: profile.createdAt.toISOString(),
+    updatedAt: profile.updatedAt.toISOString(),
+  }
+}

--- a/apps/api/src/shared/utils/slug.ts
+++ b/apps/api/src/shared/utils/slug.ts
@@ -1,0 +1,9 @@
+export function toSlug(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+}

--- a/apps/api/src/shared/utils/slug.ts
+++ b/apps/api/src/shared/utils/slug.ts
@@ -7,3 +7,19 @@ export function toSlug(text: string): string {
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "")
 }
+
+export async function generateUniqueSlug(
+  displayName: string,
+  findBySlug: (slug: string) => Promise<unknown>
+): Promise<string> {
+  const base = toSlug(displayName)
+  let candidate = base
+  let suffix = 2
+
+  while (await findBySlug(candidate)) {
+    candidate = `${base}-${suffix}`
+    suffix++
+  }
+
+  return candidate
+}


### PR DESCRIPTION
Introduce CreatorProfile to the Prisma schema (one-to-one with User, cascade delete) and add a new creators module. Implements repository, service, and types for creating, finding (by id/slug/userId) and updating creator profiles; includes slug generation utility (toSlug) and service-level validations (duplicate profile and not-found errors via AppError). Added unit tests for create/find/update behaviors and slug normalization.

closes #463 