### PR TITLE
slug

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,5 +1,6 @@
 import express, { type Express } from "express"
 import { authRouter } from "./modules/auth/routes/auth.routes.js"
+import { creatorsRouter } from "./modules/creators/routes/creator.routes.js"
 import { usersRouter } from "./modules/users/routes/user.routes.js"
 import { errorHandler } from "./shared/middleware/error-handler.js"
 
@@ -13,6 +14,7 @@ export function createApp(): Express {
   })
 
   app.use("/api/auth", authRouter)
+  app.use("/api/creators", creatorsRouter)
   app.use("/api/users", usersRouter)
 
   app.use(errorHandler)

--- a/apps/api/src/modules/creators/controllers/creator.controller.ts
+++ b/apps/api/src/modules/creators/controllers/creator.controller.ts
@@ -1,0 +1,21 @@
+import type { NextFunction, Request, Response } from "express"
+import { creatorService } from "../services/creator.service.js"
+import { toCreatorResponse } from "../types/creator.types.js"
+import { AppError } from "../../../shared/errors/app-error.js"
+
+export const creatorController = {
+  async getBySlug(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const { slug } = req.params
+      const profile = await creatorService.findBySlug(slug!)
+
+      if (!profile) {
+        throw new AppError(404, "CREATOR_NOT_FOUND", "Creator profile not found")
+      }
+
+      res.status(200).json(toCreatorResponse(profile))
+    } catch (error) {
+      next(error)
+    }
+  },
+}

--- a/apps/api/src/modules/creators/routes/creator.routes.ts
+++ b/apps/api/src/modules/creators/routes/creator.routes.ts
@@ -1,0 +1,6 @@
+import { Router } from "express"
+import { creatorController } from "../controllers/creator.controller.js"
+
+export const creatorsRouter: Router = Router()
+
+creatorsRouter.get("/:slug", creatorController.getBySlug)

--- a/apps/api/src/modules/creators/tests/creator.routes.test.ts
+++ b/apps/api/src/modules/creators/tests/creator.routes.test.ts
@@ -1,0 +1,44 @@
+import request from "supertest"
+import { beforeEach, describe, expect, it } from "vitest"
+import { createApp } from "../../../app.js"
+import { prisma } from "../../../shared/database/prisma.js"
+
+const app = createApp()
+
+beforeEach(async () => {
+  await prisma.fanProfile.deleteMany()
+  await prisma.creatorProfile.deleteMany()
+  await prisma.user.deleteMany()
+})
+
+describe("GET /api/creators/:slug", () => {
+  it("returns 404 for an unknown slug", async () => {
+    const res = await request(app).get("/api/creators/does-not-exist")
+    expect(res.status).toBe(404)
+    expect(res.body.error.code).toBe("CREATOR_NOT_FOUND")
+  })
+
+  it("returns the creator profile for a valid slug", async () => {
+    const user = await prisma.user.create({
+      data: { email: "creator@test.com", passwordHash: "hash" },
+    })
+
+    await prisma.creatorProfile.create({
+      data: {
+        userId: user.id,
+        displayName: "Solar Vibes",
+        slug: "solar-vibes",
+        bio: "Indie producer",
+        genre: "Indie",
+        location: "Lagos",
+      },
+    })
+
+    const res = await request(app).get("/api/creators/solar-vibes")
+    expect(res.status).toBe(200)
+    expect(res.body.displayName).toBe("Solar Vibes")
+    expect(res.body.slug).toBe("solar-vibes")
+    expect(res.body.bio).toBe("Indie producer")
+    expect(res.body.genre).toBe("Indie")
+  })
+})

--- a/apps/web/__tests__/creator-profile-page.test.tsx
+++ b/apps/web/__tests__/creator-profile-page.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import CreatorProfilePage from "../app/creators/[slug]/page"
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ slug: "solar-vibes" }),
+}))
+
+vi.mock("../lib/creator-client", () => ({
+  getCreatorBySlug: vi.fn().mockResolvedValue({
+    id: "cp-1",
+    userId: "u-1",
+    displayName: "Solar Vibes",
+    slug: "solar-vibes",
+    bio: "Indie producer from Lagos",
+    avatarUrl: null,
+    genre: "Indie",
+    location: "Lagos",
+    isVerified: true,
+    followerCount: 0,
+    trackCount: 0,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  }),
+}))
+
+vi.mock("../lib/auth-client", () => ({
+  loginUser: vi.fn(),
+  registerUser: vi.fn(),
+  AuthApiError: class AuthApiError extends Error {},
+}))
+
+describe("CreatorProfilePage", () => {
+  it("renders the creator's display name", async () => {
+    render(<CreatorProfilePage />)
+    expect(await screen.findByText("Solar Vibes")).toBeInTheDocument()
+  })
+
+  it("renders bio, genre, and location", async () => {
+    render(<CreatorProfilePage />)
+    expect(
+      await screen.findByText("Indie producer from Lagos")
+    ).toBeInTheDocument()
+    expect(screen.getByText("Indie")).toBeInTheDocument()
+    expect(screen.getByText("Lagos")).toBeInTheDocument()
+  })
+
+  it("renders the verified badge when creator is verified", async () => {
+    render(<CreatorProfilePage />)
+    expect(await screen.findByLabelText("Verified")).toBeInTheDocument()
+  })
+
+  it("shows default avatar when avatarUrl is null", async () => {
+    render(<CreatorProfilePage />)
+    expect(await screen.findByLabelText("Default avatar")).toBeInTheDocument()
+  })
+})

--- a/apps/web/app/creators/[slug]/page.tsx
+++ b/apps/web/app/creators/[slug]/page.tsx
@@ -1,0 +1,90 @@
+"use client"
+
+import type { CreatorProfileResponse } from "@chordially/shared"
+import { useParams } from "next/navigation"
+import { useCallback, useEffect, useState } from "react"
+import { getCreatorBySlug } from "../../../lib/creator-client"
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ok"; profile: CreatorProfileResponse }
+
+export default function CreatorProfilePage() {
+  const params = useParams<{ slug: string }>()
+  const [state, setState] = useState<LoadState>({ status: "loading" })
+
+  const load = useCallback(async () => {
+    try {
+      const profile = await getCreatorBySlug(params.slug)
+      setState({ status: "ok", profile })
+    } catch {
+      setState({ status: "error", message: "Creator not found" })
+    }
+  }, [params.slug])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  if (state.status === "loading") {
+    return <p>Loading…</p>
+  }
+
+  if (state.status === "error") {
+    return (
+      <div>
+        <h1>Not Found</h1>
+        <p>{state.message}</p>
+      </div>
+    )
+  }
+
+  const { profile } = state
+
+  return (
+    <main>
+      <div>
+        {profile.avatarUrl ? (
+          <img
+            src={profile.avatarUrl}
+            alt={`${profile.displayName}'s avatar`}
+            width={120}
+            height={120}
+          />
+        ) : (
+          <div
+            aria-label="Default avatar"
+            style={{
+              width: 120,
+              height: 120,
+              borderRadius: "50%",
+              background: "#ddd",
+            }}
+          />
+        )}
+      </div>
+
+      <h1>{profile.displayName}</h1>
+
+      {profile.bio && <p>{profile.bio}</p>}
+
+      <dl>
+        {profile.genre && (
+          <>
+            <dt>Genre</dt>
+            <dd>{profile.genre}</dd>
+          </>
+        )}
+        {profile.location && (
+          <>
+            <dt>Location</dt>
+            <dd>{profile.location}</dd>
+          </>
+        )}
+      </dl>
+
+      {profile.isVerified && <span aria-label="Verified">Verified</span>}
+    </main>
+  )
+}

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -1,0 +1,47 @@
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000"
+
+export class ApiError extends Error {
+  status: number
+
+  constructor(status: number, message: string) {
+    super(message)
+    this.name = "ApiError"
+    this.status = status
+  }
+}
+
+export async function apiFetch<T>(
+  path: string,
+  options: RequestInit = {}
+): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options.headers,
+    },
+  })
+
+  const data: unknown = await response.json().catch(() => null)
+
+  if (!response.ok) {
+    const message =
+      data &&
+      typeof data === "object" &&
+      "error" in data &&
+      data.error &&
+      typeof data.error === "object" &&
+      "message" in data.error &&
+      typeof data.error.message === "string"
+        ? data.error.message
+        : "Something went wrong"
+
+    throw new ApiError(response.status, message)
+  }
+
+  return data as T
+}
+
+export function authHeaders(token: string): Record<string, string> {
+  return { Authorization: `Bearer ${token}` }
+}

--- a/apps/web/lib/creator-client.ts
+++ b/apps/web/lib/creator-client.ts
@@ -1,0 +1,8 @@
+import type { CreatorProfileResponse } from "@chordially/shared"
+import { apiFetch } from "./api-client"
+
+export function getCreatorBySlug(
+  slug: string
+): Promise<CreatorProfileResponse> {
+  return apiFetch<CreatorProfileResponse>(`/api/creators/${encodeURIComponent(slug)}`)
+}


### PR DESCRIPTION
- generic apiFetch helper with error parsing + authHeaders util (replaces the auth-only postJson pattern for all future API calls)

- getCreatorBySlug(slug) function

- client-side rendered creator profile page with loading/error/ok states, avatar fallback, bio, genre, location, verified badge

- 4 tests covering render, bio/genre/location, verified badge, default avatar

closes #467 